### PR TITLE
Fix solgen output

### DIFF
--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -198,6 +198,7 @@ func Decrypt(input []byte, tp *TxParams) (*big.Int, error) {
 }
 
 func Lte(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("starting new precompiled contract function ", getFunctionName())
 	}
@@ -301,6 +302,7 @@ func Mul(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Lt(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("starting new precompiled contract function ", getFunctionName())
 	}
@@ -527,6 +529,7 @@ func Div(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Gt(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -632,7 +635,6 @@ func Rem(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func And(input []byte, tp *TxParams) ([]byte, error) {
-	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -668,7 +670,6 @@ func And(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Or(input []byte, tp *TxParams) ([]byte, error) {
-	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -704,7 +705,6 @@ func Or(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Xor(input []byte, tp *TxParams) ([]byte, error) {
-	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}

--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -632,6 +632,7 @@ func Rem(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func And(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -667,6 +668,7 @@ func And(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Or(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -702,6 +704,7 @@ func Or(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Xor(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -737,6 +740,7 @@ func Xor(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Eq(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}
@@ -772,6 +776,7 @@ func Eq(input []byte, tp *TxParams) ([]byte, error) {
 }
 
 func Ne(input []byte, tp *TxParams) ([]byte, error) {
+	//solgen: comparison
 	if shouldPrintPrecompileInfo(tp) {
 		logger.Info("Starting new precompiled contract function ", getFunctionName())
 	}

--- a/solgen/common.js
+++ b/solgen/common.js
@@ -1,7 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.valueIsPlaintext = exports.valueIsEncrypted = exports.BindMathOperators = exports.ShorthandOperations = exports.UnderlyingTypes = exports.EPlaintextType = exports.EInputType = void 0;
+exports.valueIsPlaintext = exports.valueIsEncrypted = exports.BindMathOperators = exports.ShorthandOperations = exports.UnderlyingTypes = exports.EPlaintextType = exports.EComparisonType = exports.EInputType = void 0;
 exports.EInputType = ['ebool', 'euint8', 'euint16', 'euint32'];
+exports.EComparisonType = ['ebool'];
 exports.EPlaintextType = ['bool', 'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256'];
 exports.UnderlyingTypes = {
     euint8: 'uint256',

--- a/solgen/common.ts
+++ b/solgen/common.ts
@@ -1,4 +1,5 @@
 export const EInputType = ['ebool', 'euint8', 'euint16', 'euint32'];
+export const EComparisonType = ['ebool'];
 export const EPlaintextType = ['bool', 'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'uint256'];
 export type EUintType = 'ebool' | 'euint8' | 'euint16' | 'euint32';
 export type PlaintextType = 'bool' | 'uint8' | 'uint16' | 'uint32' | 'uint64' | 'uint128' | 'uint256';

--- a/solgen/contracts_parser.js
+++ b/solgen/contracts_parser.js
@@ -135,6 +135,7 @@ function analyzeGoFile(filePath) {
                             funcName = trimmedLine.split(' ')[1].split('(')[0].toLowerCase();
                             // If we match the high-level function, set the flag and initialize brace counting
                             isInsideHighLevelFunction = true;
+                            isComparisonMathOp = false;
                             braceDepth = 1; // starts with the opening brace of the function
                         }
                     }

--- a/solgen/contracts_parser.js
+++ b/solgen/contracts_parser.js
@@ -48,7 +48,7 @@ var specificFunctions = [
 ];
 function analyzeGoFile(filePath) {
     return __awaiter(this, void 0, void 0, function () {
-        var fileContent, lines, highLevelFunctionRegex, solgenCommentRegex, solgenReturnsComment, solgenInputPlaintextComment, solgenOutputPlaintextComment, solgenInput2Comment, specificFunctionAnalysis, isInsideHighLevelFunction, braceDepth, funcName, returnType, inputs, _i, lines_1, line, trimmedLine, _a, specificFunctions_1, keyfn, needsSameType, amount;
+        var fileContent, lines, highLevelFunctionRegex, solgenCommentRegex, solgenReturnsComment, solgenInputPlaintextComment, solgenOutputPlaintextComment, solgenInput2Comment, solgenComparisonMathOp, specificFunctionAnalysis, isInsideHighLevelFunction, isComparisonMathOp, braceDepth, funcName, returnType, inputs, _i, lines_1, line, trimmedLine, _a, specificFunctions_1, keyfn, needsSameType, amount;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0: return [4 /*yield*/, fs.promises.readFile(filePath, 'utf-8')];
@@ -61,8 +61,10 @@ function analyzeGoFile(filePath) {
                     solgenInputPlaintextComment = /input plaintext/;
                     solgenOutputPlaintextComment = /output plaintext/;
                     solgenInput2Comment = /input2 /;
+                    solgenComparisonMathOp = /comparison/;
                     specificFunctionAnalysis = [];
                     isInsideHighLevelFunction = false;
+                    isComparisonMathOp = false;
                     braceDepth = 0;
                     funcName = "";
                     returnType = undefined;
@@ -85,6 +87,9 @@ function analyzeGoFile(filePath) {
                                 }
                                 if (solgenOutputPlaintextComment.test(trimmedLine)) {
                                     returnType = 'plaintext';
+                                }
+                                if (solgenComparisonMathOp.test(trimmedLine)) {
+                                    isComparisonMathOp = true;
                                 }
                             }
                             braceDepth += (trimmedLine.match(/\{/g) || []).length;
@@ -117,7 +122,8 @@ function analyzeGoFile(filePath) {
                                         paramsCount: amount,
                                         needsSameType: needsSameType,
                                         returnType: returnType,
-                                        inputTypes: inputs.slice(0, amount)
+                                        inputTypes: inputs.slice(0, amount),
+                                        isComparisonMathOp: isComparisonMathOp
                                     });
                                 }
                             }

--- a/solgen/contracts_parser.ts
+++ b/solgen/contracts_parser.ts
@@ -96,7 +96,7 @@ async function analyzeGoFile(filePath: string): Promise<FunctionAnalysis[] | nul
                         needsSameType: needsSameType,
                         returnType: returnType,
                         inputTypes: inputs.slice(0, amount),
-                        isComparisonMathOp
+                        isComparisonMathOp : isComparisonMathOp
                     });
                 }
             }
@@ -107,6 +107,7 @@ async function analyzeGoFile(filePath: string): Promise<FunctionAnalysis[] | nul
             funcName = trimmedLine.split(' ')[1].split('(')[0].toLowerCase();
             // If we match the high-level function, set the flag and initialize brace counting
             isInsideHighLevelFunction = true;
+            isComparisonMathOp = false;
             braceDepth = 1; // starts with the opening brace of the function
         }
     }

--- a/solgen/contracts_parser.ts
+++ b/solgen/contracts_parser.ts
@@ -9,6 +9,7 @@ interface FunctionAnalysis {
     needsSameType: boolean;
     inputTypes: ParamTypes[],
     returnType?: string;
+    isComparisonMathOp: boolean;
 }
 
 // helps us know how many input parameters there are
@@ -29,9 +30,11 @@ async function analyzeGoFile(filePath: string): Promise<FunctionAnalysis[] | nul
     const solgenInputPlaintextComment = /input plaintext/;
     const solgenOutputPlaintextComment = /output plaintext/;
     const solgenInput2Comment = /input2 /;
+    const solgenComparisonMathOp = /comparison/;
     const specificFunctionAnalysis: FunctionAnalysis[] = [];
 
     let isInsideHighLevelFunction = false;
+    let isComparisonMathOp = false;
     let braceDepth = 0;
     let funcName = "";
     let returnType = undefined;
@@ -54,6 +57,9 @@ async function analyzeGoFile(filePath: string): Promise<FunctionAnalysis[] | nul
                 }
                 if(solgenOutputPlaintextComment.test(trimmedLine)) {
                     returnType = 'plaintext';
+                }
+                if(solgenComparisonMathOp.test(trimmedLine)) {
+                    isComparisonMathOp = true;
                 }
             }
 
@@ -89,7 +95,8 @@ async function analyzeGoFile(filePath: string): Promise<FunctionAnalysis[] | nul
                         paramsCount: amount,
                         needsSameType: needsSameType,
                         returnType: returnType,
-                        inputTypes: inputs.slice(0, amount)
+                        inputTypes: inputs.slice(0, amount),
+                        isComparisonMathOp
                     });
                 }
             }

--- a/solgen/solgen.js
+++ b/solgen/solgen.js
@@ -231,18 +231,20 @@ var main = function () { return __awaiter(void 0, void 0, void 0, function () {
                         if (!(0, common_1.valueIsEncrypted)(encType)) {
                             throw new Error("InputType mismatch");
                         }
-                        outputFile += (0, templates_1.OperatorOverloadDecl)(value.func, value.operator, encType, value.unary);
+                        if (!common_1.EComparisonType.includes(encType)) {
+                            outputFile += (0, templates_1.OperatorOverloadDecl)(value.func, value.operator, encType, value.unary);
+                        }
                     }
                 });
                 outputFile += "\n// ********** BINDING DEFS ************* //\n";
                 common_1.EInputType.forEach(function (encryptedType) {
-                    common_1.BindMathOperators.forEach(function (bindMathOp) {
-                        if (common_1.ShorthandOperations.filter(function (value) { return value.func === bindMathOp; }).length === 0) {
-                            // console.log(`${bindMathOp}`)
-                            outputFile += (0, templates_1.BindingsWithoutOperator)(bindMathOp, encryptedType);
-                        }
-                    });
                     if (!common_1.EComparisonType.includes(encryptedType)) {
+                        common_1.BindMathOperators.forEach(function (bindMathOp) {
+                            if (common_1.ShorthandOperations.filter(function (value) { return value.func === bindMathOp; }).length === 0) {
+                                // console.log(`${bindMathOp}`)
+                                outputFile += (0, templates_1.BindingsWithoutOperator)(bindMathOp, encryptedType);
+                            }
+                        });
                         outputFile += (0, templates_1.BindingLibraryType)(encryptedType);
                         common_1.BindMathOperators.forEach(function (fnToBind) {
                             var foundFnDef = solidityHeaders.find(function (funcHeader) {

--- a/solgen/solgen.ts
+++ b/solgen/solgen.ts
@@ -11,7 +11,15 @@ import {
     SolTemplate2Arg,
     SolTemplate3Arg
 } from "./templates";
-import {AllTypes, BindMathOperators, EInputType, EPlaintextType, ShorthandOperations, valueIsEncrypted} from "./common";
+import {
+    AllTypes,
+    BindMathOperators,
+    EComparisonType,
+    EInputType,
+    EPlaintextType,
+    ShorthandOperations,
+    valueIsEncrypted
+} from "./common";
 
 interface FunctionMetadata {
     functionName: string;
@@ -19,6 +27,7 @@ interface FunctionMetadata {
     hasDifferentInputTypes: boolean;
     returnValueType?: string;
     inputs: AllTypes[];
+    isComparisonMathOp : boolean;
 }
 
 const generateMetadataPayload = async (): Promise<FunctionMetadata[]> => {
@@ -31,6 +40,7 @@ const generateMetadataPayload = async (): Promise<FunctionMetadata[]> => {
             inputCount: value.paramsCount,
             returnValueType: value.returnType,
             inputs: value.inputTypes,
+            isComparisonMathOp: value.isComparisonMathOp
         }
     })
 }
@@ -107,7 +117,8 @@ const genSolidityFunctionHeaders = (metadata: FunctionMetadata): string[] => {
         inputCount,
         hasDifferentInputTypes,
         returnValueType,
-        inputs
+        inputs,
+        isComparisonMathOp
     } = metadata;
 
     let functions: string[][] = [];
@@ -117,6 +128,9 @@ const genSolidityFunctionHeaders = (metadata: FunctionMetadata): string[] => {
         switch (input) {
             case "encrypted":
                 for (let inputType of EInputType) {
+                    if (inputs.length === 2 && !isComparisonMathOp && EComparisonType.includes(input)) {
+                        continue;
+                    }
                     inputVariants.push(`input${idx} ${inputType}`)
                 }
                 break;

--- a/solgen/solgen.ts
+++ b/solgen/solgen.ts
@@ -256,23 +256,24 @@ const main = async () => {
             if (!valueIsEncrypted(encType)) {
                 throw new Error("InputType mismatch");
             }
-            outputFile += OperatorOverloadDecl(value.func, value.operator, encType, value.unary)
+            if (!EComparisonType.includes(encType)) {
+                outputFile += OperatorOverloadDecl(value.func, value.operator, encType, value.unary)
+            }
         }
     });
 
     outputFile += `\n// ********** BINDING DEFS ************* //\n`
 
     EInputType.forEach(encryptedType => {
-
-        BindMathOperators.forEach(bindMathOp => {
-
-            if (ShorthandOperations.filter(value => value.func === bindMathOp).length === 0) {
-                // console.log(`${bindMathOp}`)
-                outputFile += BindingsWithoutOperator(bindMathOp, encryptedType);
-            }
-        });
-
         if (!EComparisonType.includes(encryptedType)) {
+            BindMathOperators.forEach(bindMathOp => {
+
+                if (ShorthandOperations.filter(value => value.func === bindMathOp).length === 0) {
+                    // console.log(`${bindMathOp}`)
+                    outputFile += BindingsWithoutOperator(bindMathOp, encryptedType);
+                }
+            });
+
             outputFile += BindingLibraryType(encryptedType);
             BindMathOperators.forEach(fnToBind => {
                 let foundFnDef = solidityHeaders.find((funcHeader) => {

--- a/solgen/solgen.ts
+++ b/solgen/solgen.ts
@@ -128,7 +128,7 @@ const genSolidityFunctionHeaders = (metadata: FunctionMetadata): string[] => {
         switch (input) {
             case "encrypted":
                 for (let inputType of EInputType) {
-                    if (inputs.length === 2 && !isComparisonMathOp && EComparisonType.includes(input)) {
+                    if (inputs.length === 2 && !isComparisonMathOp && EComparisonType.includes(inputType)) {
                         continue;
                     }
                     inputVariants.push(`input${idx} ${inputType}`)
@@ -265,25 +265,27 @@ const main = async () => {
             }
         });
 
-        outputFile += BindingLibraryType(encryptedType);
-        BindMathOperators.forEach(fnToBind => {
-            let foundFnDef = solidityHeaders.find((funcHeader) => {
-                const fnDef = parseFunctionDefinition(funcHeader);
-                const input = fnDef.inputs[0];
+        if (!EComparisonType.includes(encryptedType)) {
+            outputFile += BindingLibraryType(encryptedType);
+            BindMathOperators.forEach(fnToBind => {
+                let foundFnDef = solidityHeaders.find((funcHeader) => {
+                    const fnDef = parseFunctionDefinition(funcHeader);
+                    const input = fnDef.inputs[0];
 
-                if (!EInputType.includes(input)) {
-                    return false;
+                    if (!EInputType.includes(input)) {
+                        return false;
+                    }
+
+                    return (fnDef.funcName === fnToBind && fnDef.inputs.every(item => item === input))
+                });
+
+                if (foundFnDef) {
+                    const fnDef = parseFunctionDefinition(foundFnDef);
+                    outputFile += OperatorBinding(fnDef.funcName, encryptedType, fnDef.inputs.length === 1)
                 }
-
-                return (fnDef.funcName === fnToBind && fnDef.inputs.every(item => item === input))
             });
-
-            if (foundFnDef) {
-                const fnDef = parseFunctionDefinition(foundFnDef);
-                outputFile += OperatorBinding(fnDef.funcName, encryptedType, fnDef.inputs.length === 1)
-            }
-        });
-        outputFile += PostFix();
+            outputFile += PostFix();
+        }
     })
 
 

--- a/solgen/templates.js
+++ b/solgen/templates.js
@@ -19,6 +19,9 @@ var castFromPlaintext = function (name, toType) {
 var castFromBytes = function (name, toType) {
     return "Impl.verify(".concat(name, ", Common.").concat(toType, "_tfhe_go)");
 };
+var castToEbool = function (name, fromType) {
+    return "function asEbool(".concat(fromType, " value) internal pure returns (ebool) {\n        return ne(").concat(name, ",  as").concat(capitalize(fromType), "(0));\n    }\n");
+};
 var AsTypeFunction = function (fromType, toType) {
     var castString = castFromEncrypted(fromType, toType, "value");
     if (fromType === 'bytes memory') {
@@ -26,6 +29,9 @@ var AsTypeFunction = function (fromType, toType) {
     }
     else if (common_1.EPlaintextType.includes(fromType)) {
         castString = castFromPlaintext("value", toType);
+    }
+    else if (toType === "ebool") {
+        return castToEbool("value", fromType);
     }
     else if (!common_1.EInputType.includes(fromType)) {
         throw new Error("Unsupported type for casting: ".concat(fromType));
@@ -133,6 +139,9 @@ exports.BindingLibraryType = BindingLibraryType;
 var OperatorBinding = function (funcName, forType, unary) {
     var unaryParameters = unary ? 'lhs' : 'lhs, rhs';
     var funcParams = unaryParameters.split(',').map(function (key) { return "".concat(forType, " ").concat(key); }).join(', ');
+    if (funcName === "eq") {
+        forType = "ebool";
+    }
     return "\nfunction ".concat(funcName, "(").concat(funcParams, ") pure internal returns (").concat(forType, ") {\n    return TFHE.").concat(funcName, "(").concat(unaryParameters, ");\n}");
 };
 exports.OperatorBinding = OperatorBinding;

--- a/solgen/templates.ts
+++ b/solgen/templates.ts
@@ -181,6 +181,13 @@ const castFromBytes = (name: string, toType: string): string => {
     return `Impl.verify(${name}, Common.${toType}_tfhe_go)`;
 }
 
+const castToEbool = (name: string, fromType: string): string => {
+    return `function asEbool(${fromType} value) internal pure returns (ebool) {
+        return ne(${name},  as${capitalize(fromType)}(0));
+    }\n`
+}
+
+
 
 export const AsTypeFunction = (fromType: string, toType: string) => {
 
@@ -189,6 +196,8 @@ export const AsTypeFunction = (fromType: string, toType: string) => {
         castString = castFromBytes("value", toType)
     } else if (EPlaintextType.includes(fromType)) {
         castString = castFromPlaintext("value", toType);
+    } else if (toType === "ebool") {
+        return castToEbool("value", fromType);
     } else if (!EInputType.includes(fromType)) {
         throw new Error(`Unsupported type for casting: ${fromType}`)
     }
@@ -358,6 +367,10 @@ export const BindingLibraryType = (type: string) => {
 export const OperatorBinding = (funcName: string, forType: string, unary: boolean) => {
     let unaryParameters = unary ? 'lhs' : 'lhs, rhs';
     let funcParams = unaryParameters.split(',').map((key) => {return `${forType} ${key}`}).join(', ')
+
+    if (funcName === "eq") {
+        forType = "ebool"
+    }
 
     return `\nfunction ${funcName}(${funcParams}) pure internal returns (${forType}) {
     return TFHE.${funcName}(${unaryParameters});

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -152,61 +152,6 @@ library TFHE {
         result = getValue(output);
     }
 
-function add(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return ebool.wrap(result);
-
-}
-function add(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint8.wrap(result);
-
-}
-function add(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint16.wrap(result);
-
-}
-function add(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint32.wrap(result);
-
-}
-function add(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint8.wrap(result);
-
-}
 function add(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -240,17 +185,6 @@ function add(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function add(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint16.wrap(result);
-
-}
 function add(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -279,17 +213,6 @@ function add(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
-    return euint32.wrap(result);
-
-}
-function add(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
     return euint32.wrap(result);
@@ -326,12 +249,6 @@ function add(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).add);
     return euint32.wrap(result);
-
-}
-function reencrypt(ebool value, bytes32 publicKey) internal pure returns (bytes memory) {
-    uint256 unwrapped = ebool.unwrap(value);
-
-    return Impl.reencrypt(unwrapped, publicKey);
 
 }
 function reencrypt(euint8 value, bytes32 publicKey) internal pure returns (bytes memory) {
@@ -392,61 +309,6 @@ function decrypt(euint32 input1) internal pure  returns (uint32) {
     return Common.bigIntToUint32(result);
 }
 
-function lte(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return ebool.wrap(result);
-
-}
-function lte(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint8.wrap(result);
-
-}
-function lte(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint16.wrap(result);
-
-}
-function lte(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
-
-}
-function lte(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint8.wrap(result);
-
-}
 function lte(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -480,17 +342,6 @@ function lte(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function lte(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint16.wrap(result);
-
-}
 function lte(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -519,17 +370,6 @@ function lte(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
-
-}
-function lte(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
     return euint32.wrap(result);
@@ -568,61 +408,6 @@ function lte(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function sub(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return ebool.wrap(result);
-
-}
-function sub(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint8.wrap(result);
-
-}
-function sub(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint16.wrap(result);
-
-}
-function sub(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint32.wrap(result);
-
-}
-function sub(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint8.wrap(result);
-
-}
 function sub(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -656,17 +441,6 @@ function sub(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function sub(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint16.wrap(result);
-
-}
 function sub(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -695,17 +469,6 @@ function sub(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
-    return euint32.wrap(result);
-
-}
-function sub(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).sub);
     return euint32.wrap(result);
@@ -744,61 +507,6 @@ function sub(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function mul(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return ebool.wrap(result);
-
-}
-function mul(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint8.wrap(result);
-
-}
-function mul(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint16.wrap(result);
-
-}
-function mul(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint32.wrap(result);
-
-}
-function mul(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint8.wrap(result);
-
-}
 function mul(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -832,17 +540,6 @@ function mul(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function mul(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint16.wrap(result);
-
-}
 function mul(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -871,17 +568,6 @@ function mul(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
-    return euint32.wrap(result);
-
-}
-function mul(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).mul);
     return euint32.wrap(result);
@@ -920,61 +606,6 @@ function mul(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function lt(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return ebool.wrap(result);
-
-}
-function lt(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint8.wrap(result);
-
-}
-function lt(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint16.wrap(result);
-
-}
-function lt(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
-
-}
-function lt(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint8.wrap(result);
-
-}
 function lt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1008,17 +639,6 @@ function lt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function lt(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint16.wrap(result);
-
-}
 function lt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1047,17 +667,6 @@ function lt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
-
-}
-function lt(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
     return euint32.wrap(result);
@@ -1324,61 +933,6 @@ function req(euint32 input1) internal pure {
     FheOps(Precompiles.Fheos).req(inputAsBytes);
 }
 
-function div(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return ebool.wrap(result);
-
-}
-function div(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint8.wrap(result);
-
-}
-function div(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint16.wrap(result);
-
-}
-function div(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint32.wrap(result);
-
-}
-function div(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint8.wrap(result);
-
-}
 function div(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1412,17 +966,6 @@ function div(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function div(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint16.wrap(result);
-
-}
 function div(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1451,17 +994,6 @@ function div(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
-    return euint32.wrap(result);
-
-}
-function div(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).div);
     return euint32.wrap(result);
@@ -1500,61 +1032,6 @@ function div(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function gt(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return ebool.wrap(result);
-
-}
-function gt(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint8.wrap(result);
-
-}
-function gt(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint16.wrap(result);
-
-}
-function gt(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
-
-}
-function gt(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint8.wrap(result);
-
-}
 function gt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1588,17 +1065,6 @@ function gt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function gt(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint16.wrap(result);
-
-}
 function gt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1627,17 +1093,6 @@ function gt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
-
-}
-function gt(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
     return euint32.wrap(result);
@@ -1676,61 +1131,6 @@ function gt(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function gte(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return ebool.wrap(result);
-
-}
-function gte(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint8.wrap(result);
-
-}
-function gte(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint16.wrap(result);
-
-}
-function gte(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint32.wrap(result);
-
-}
-function gte(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint8.wrap(result);
-
-}
 function gte(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1764,17 +1164,6 @@ function gte(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function gte(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint16.wrap(result);
-
-}
 function gte(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1803,17 +1192,6 @@ function gte(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
-    return euint32.wrap(result);
-
-}
-function gte(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gte);
     return euint32.wrap(result);
@@ -1852,61 +1230,6 @@ function gte(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function rem(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return ebool.wrap(result);
-
-}
-function rem(ebool lhs, euint8 rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint8.wrap(result);
-
-}
-function rem(ebool lhs, euint16 rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint16.wrap(result);
-
-}
-function rem(ebool lhs, euint32 rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint32.wrap(result);
-
-}
-function rem(euint8 lhs, ebool rhs) internal pure returns (euint8) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint8.wrap(result);
-
-}
 function rem(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1940,17 +1263,6 @@ function rem(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function rem(euint16 lhs, ebool rhs) internal pure returns (euint16) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint16.wrap(result);
-
-}
 function rem(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
@@ -1979,17 +1291,6 @@ function rem(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     }
     uint256 unwrappedInput1 = euint16.unwrap(lhs);
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
-    return euint32.wrap(result);
-
-}
-function rem(euint32 lhs, ebool rhs) internal pure returns (euint32) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).rem);
     return euint32.wrap(result);
@@ -3881,29 +3182,6 @@ function operatorAndEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
 
 using {BindingsEbool.eq} for ebool global;
 
-library BindingsEbool {
-function add(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.add(lhs, rhs);
-}
-function mul(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.mul(lhs, rhs);
-}
-function div(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.div(lhs, rhs);
-}
-function sub(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.sub(lhs, rhs);
-}
-function eq(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.eq(lhs, rhs);
-}
-function and(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.and(lhs, rhs);
-}
-function or(ebool lhs, ebool  rhs) pure internal returns (ebool) {
-    return TFHE.or(lhs, rhs);
-}
-}
 using {BindingsEuint8.eq} for euint8 global;
 
 library BindingsEuint8 {

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -309,7 +309,62 @@ function decrypt(euint32 input1) internal pure  returns (uint32) {
     return Common.bigIntToUint32(result);
 }
 
-function lte(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function lte(ebool lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(rhs);
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(ebool lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(ebool lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(ebool lhs, euint32 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(euint8 lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint8.unwrap(lhs);
+    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -317,10 +372,10 @@ function lte(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function lte(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -328,10 +383,10 @@ function lte(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function lte(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -339,10 +394,10 @@ function lte(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function lte(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -350,10 +405,21 @@ function lte(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function lte(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint16.unwrap(lhs);
+    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -361,10 +427,10 @@ function lte(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function lte(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -372,10 +438,10 @@ function lte(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function lte(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -383,10 +449,10 @@ function lte(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function lte(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -394,10 +460,21 @@ function lte(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lte(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function lte(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint32.unwrap(lhs);
+    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
+    return ebool.wrap(result);
+
+}
+function lte(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -405,7 +482,7 @@ function lte(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lte);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function sub(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
@@ -606,7 +683,62 @@ function mul(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function lt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function lt(ebool lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(rhs);
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(ebool lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(ebool lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(ebool lhs, euint32 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(euint8 lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint8.unwrap(lhs);
+    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -614,10 +746,10 @@ function lt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function lt(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -625,10 +757,10 @@ function lt(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function lt(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -636,10 +768,10 @@ function lt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function lt(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -647,10 +779,21 @@ function lt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function lt(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint16.unwrap(lhs);
+    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -658,10 +801,10 @@ function lt(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function lt(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -669,10 +812,10 @@ function lt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function lt(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -680,10 +823,10 @@ function lt(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function lt(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -691,10 +834,21 @@ function lt(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function lt(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function lt(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint32.unwrap(lhs);
+    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
+    return ebool.wrap(result);
+
+}
+function lt(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -702,7 +856,7 @@ function lt(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).lt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function cmux(ebool input1, ebool input2, ebool input3) internal pure returns (ebool) {
@@ -1032,7 +1186,62 @@ function div(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function gt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function gt(ebool lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(rhs);
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(ebool lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(ebool lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(ebool lhs, euint32 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = ebool.unwrap(lhs);
+    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(euint8 lhs, ebool rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint8.unwrap(lhs);
+    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1040,10 +1249,10 @@ function gt(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function gt(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1051,10 +1260,10 @@ function gt(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function gt(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1062,10 +1271,10 @@ function gt(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function gt(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1073,10 +1282,21 @@ function gt(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function gt(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint16.unwrap(lhs);
+    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1084,10 +1304,10 @@ function gt(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function gt(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1095,10 +1315,10 @@ function gt(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function gt(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1106,10 +1326,10 @@ function gt(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function gt(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1117,10 +1337,21 @@ function gt(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function gt(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function gt(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
+    if(!isInitialized(lhs) || !isInitialized(rhs)) {
+        revert("One or more inputs are not initialized.");
+    }
+    uint256 unwrappedInput1 = euint32.unwrap(lhs);
+    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
+
+    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
+    return ebool.wrap(result);
+
+}
+function gt(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1128,7 +1359,7 @@ function gt(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).gt);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function gte(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
@@ -1329,62 +1560,7 @@ function rem(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     return euint32.wrap(result);
 
 }
-function and(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function and(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1392,10 +1568,10 @@ function and(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function and(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function and(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1403,10 +1579,10 @@ function and(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function and(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function and(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1414,10 +1590,10 @@ function and(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function and(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function and(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1425,21 +1601,10 @@ function and(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function and(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function and(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1447,10 +1612,10 @@ function and(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function and(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function and(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1458,10 +1623,10 @@ function and(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function and(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function and(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1469,10 +1634,10 @@ function and(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function and(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function and(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1480,21 +1645,10 @@ function and(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function and(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
-
-}
-function and(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function and(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1502,65 +1656,10 @@ function and(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function or(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function or(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1568,10 +1667,10 @@ function or(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function or(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function or(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1579,10 +1678,10 @@ function or(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function or(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function or(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1590,10 +1689,10 @@ function or(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function or(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function or(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1601,21 +1700,10 @@ function or(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function or(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function or(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1623,10 +1711,10 @@ function or(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function or(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function or(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1634,10 +1722,10 @@ function or(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function or(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function or(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1645,10 +1733,10 @@ function or(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function or(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function or(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1656,21 +1744,10 @@ function or(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function or(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
-
-}
-function or(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function or(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1678,65 +1755,10 @@ function or(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function xor(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function xor(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1744,10 +1766,10 @@ function xor(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function xor(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function xor(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1755,10 +1777,10 @@ function xor(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function xor(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function xor(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1766,10 +1788,10 @@ function xor(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function xor(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function xor(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1777,21 +1799,10 @@ function xor(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function xor(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function xor(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1799,10 +1810,10 @@ function xor(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function xor(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function xor(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1810,10 +1821,10 @@ function xor(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function xor(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function xor(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1821,10 +1832,10 @@ function xor(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function xor(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function xor(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1832,21 +1843,10 @@ function xor(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function xor(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
-
-}
-function xor(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function xor(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1854,7 +1854,7 @@ function xor(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
 function eq(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2209,62 +2209,7 @@ function ne(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function min(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function min(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2272,10 +2217,10 @@ function min(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function min(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function min(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2283,10 +2228,10 @@ function min(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function min(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function min(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2294,10 +2239,10 @@ function min(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function min(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function min(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2305,21 +2250,10 @@ function min(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function min(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function min(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2327,10 +2261,10 @@ function min(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function min(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function min(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2338,10 +2272,10 @@ function min(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function min(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function min(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2349,10 +2283,10 @@ function min(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function min(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function min(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2360,21 +2294,10 @@ function min(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function min(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
-
-}
-function min(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function min(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2382,65 +2305,10 @@ function min(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function max(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function max(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2448,10 +2316,10 @@ function max(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function max(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function max(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2459,10 +2327,10 @@ function max(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function max(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function max(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2470,10 +2338,10 @@ function max(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function max(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function max(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2481,21 +2349,10 @@ function max(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function max(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function max(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2503,10 +2360,10 @@ function max(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function max(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function max(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2514,10 +2371,10 @@ function max(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function max(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function max(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2525,10 +2382,10 @@ function max(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function max(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function max(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2536,21 +2393,10 @@ function max(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function max(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
-
-}
-function max(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function max(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2558,65 +2404,10 @@ function max(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shl(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function shl(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2624,10 +2415,10 @@ function shl(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function shl(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function shl(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2635,10 +2426,10 @@ function shl(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shl(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function shl(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2646,10 +2437,10 @@ function shl(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shl(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function shl(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2657,21 +2448,10 @@ function shl(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shl(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function shl(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2679,10 +2459,10 @@ function shl(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shl(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function shl(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2690,10 +2470,10 @@ function shl(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shl(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function shl(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2701,10 +2481,10 @@ function shl(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shl(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function shl(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2712,21 +2492,10 @@ function shl(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shl(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
-
-}
-function shl(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function shl(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2734,65 +2503,10 @@ function shl(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shr(ebool lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(rhs);
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(ebool lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(ebool lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(ebool lhs, euint32 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = ebool.unwrap(lhs);
-    uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(euint8 lhs, ebool rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint8.unwrap(lhs);
-    uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
+function shr(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2800,10 +2514,10 @@ function shr(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 
 }
-function shr(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
+function shr(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2811,10 +2525,10 @@ function shr(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shr(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
+function shr(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2822,10 +2536,10 @@ function shr(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shr(euint16 lhs, ebool rhs) internal pure returns (ebool) {
+function shr(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2833,21 +2547,10 @@ function shr(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shr(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint16.unwrap(lhs);
-    uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
+function shr(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2855,10 +2558,10 @@ function shr(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 
 }
-function shr(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
+function shr(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2866,10 +2569,10 @@ function shr(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shr(euint32 lhs, ebool rhs) internal pure returns (ebool) {
+function shr(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2877,10 +2580,10 @@ function shr(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shr(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
+function shr(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2888,21 +2591,10 @@ function shr(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
-function shr(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
-    if(!isInitialized(lhs) || !isInitialized(rhs)) {
-        revert("One or more inputs are not initialized.");
-    }
-    uint256 unwrappedInput1 = euint32.unwrap(lhs);
-    uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
-
-    uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
-
-}
-function shr(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
+function shr(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2910,7 +2602,7 @@ function shr(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 
 }
 function not(ebool input1) internal pure  returns (ebool) {
@@ -2924,7 +2616,7 @@ function not(ebool input1) internal pure  returns (ebool) {
     return ebool.wrap(result);
 }
 
-function not(euint8 input1) internal pure  returns (ebool) {
+function not(euint8 input1) internal pure  returns (euint8) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2932,10 +2624,10 @@ function not(euint8 input1) internal pure  returns (ebool) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return ebool.wrap(result);
+    return euint8.wrap(result);
 }
 
-function not(euint16 input1) internal pure  returns (ebool) {
+function not(euint16 input1) internal pure  returns (euint16) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2943,10 +2635,10 @@ function not(euint16 input1) internal pure  returns (ebool) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return ebool.wrap(result);
+    return euint16.wrap(result);
 }
 
-function not(euint32 input1) internal pure  returns (ebool) {
+function not(euint32 input1) internal pure  returns (euint32) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2954,7 +2646,7 @@ function not(euint32 input1) internal pure  returns (ebool) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return ebool.wrap(result);
+    return euint32.wrap(result);
 }
 
 // ********** TYPE CASTING ************* //
@@ -2968,7 +2660,7 @@ function asEuint32(ebool value) internal pure returns (euint32) {
         return euint32.wrap(Impl.cast(ebool.unwrap(value), Common.euint32_tfhe_go));
     }
 function asEbool(euint8 value) internal pure returns (ebool) {
-        return ebool.wrap(Impl.cast(euint8.unwrap(value), Common.ebool_tfhe_go));
+        return ne(value,  asEuint8(0));
     }
 function asEuint16(euint8 value) internal pure returns (euint16) {
         return euint16.wrap(Impl.cast(euint8.unwrap(value), Common.euint16_tfhe_go));
@@ -2977,7 +2669,7 @@ function asEuint32(euint8 value) internal pure returns (euint32) {
         return euint32.wrap(Impl.cast(euint8.unwrap(value), Common.euint32_tfhe_go));
     }
 function asEbool(euint16 value) internal pure returns (ebool) {
-        return ebool.wrap(Impl.cast(euint16.unwrap(value), Common.ebool_tfhe_go));
+        return ne(value,  asEuint16(0));
     }
 function asEuint8(euint16 value) internal pure returns (euint8) {
         return euint8.wrap(Impl.cast(euint16.unwrap(value), Common.euint8_tfhe_go));
@@ -2986,7 +2678,7 @@ function asEuint32(euint16 value) internal pure returns (euint32) {
         return euint32.wrap(Impl.cast(euint16.unwrap(value), Common.euint32_tfhe_go));
     }
 function asEbool(euint32 value) internal pure returns (ebool) {
-        return ebool.wrap(Impl.cast(euint32.unwrap(value), Common.ebool_tfhe_go));
+        return ne(value,  asEuint32(0));
     }
 function asEuint8(euint32 value) internal pure returns (euint8) {
         return euint8.wrap(Impl.cast(euint32.unwrap(value), Common.euint8_tfhe_go));
@@ -3022,12 +2714,6 @@ function asEuint32(bytes memory value) internal pure returns (euint32) {
 }
 // ********** OPERATOR OVERLOADING ************* //
 
-using {operatorAddEbool as +, BindingsEbool.add} for ebool global;
-
-function operatorAddEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.add(lhs, rhs);
-}
-
 using {operatorAddEuint8 as +, BindingsEuint8.add} for euint8 global;
 
 function operatorAddEuint8(euint8 lhs, euint8  rhs) pure returns (euint8) {
@@ -3044,12 +2730,6 @@ using {operatorAddEuint32 as +, BindingsEuint32.add} for euint32 global;
 
 function operatorAddEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
     return TFHE.add(lhs, rhs);
-}
-
-using {operatorSubEbool as -, BindingsEbool.sub} for ebool global;
-
-function operatorSubEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.sub(lhs, rhs);
 }
 
 using {operatorSubEuint8 as -, BindingsEuint8.sub} for euint8 global;
@@ -3070,12 +2750,6 @@ function operatorSubEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
     return TFHE.sub(lhs, rhs);
 }
 
-using {operatorMulEbool as *, BindingsEbool.mul} for ebool global;
-
-function operatorMulEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.mul(lhs, rhs);
-}
-
 using {operatorMulEuint8 as *, BindingsEuint8.mul} for euint8 global;
 
 function operatorMulEuint8(euint8 lhs, euint8  rhs) pure returns (euint8) {
@@ -3092,12 +2766,6 @@ using {operatorMulEuint32 as *, BindingsEuint32.mul} for euint32 global;
 
 function operatorMulEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
     return TFHE.mul(lhs, rhs);
-}
-
-using {operatorDivEbool as /, BindingsEbool.div} for ebool global;
-
-function operatorDivEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.div(lhs, rhs);
 }
 
 using {operatorDivEuint8 as /, BindingsEuint8.div} for euint8 global;
@@ -3118,12 +2786,6 @@ function operatorDivEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
     return TFHE.div(lhs, rhs);
 }
 
-using {operatorOrEbool as |, BindingsEbool.or} for ebool global;
-
-function operatorOrEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.or(lhs, rhs);
-}
-
 using {operatorOrEuint8 as |, BindingsEuint8.or} for euint8 global;
 
 function operatorOrEuint8(euint8 lhs, euint8  rhs) pure returns (euint8) {
@@ -3140,12 +2802,6 @@ using {operatorOrEuint32 as |, BindingsEuint32.or} for euint32 global;
 
 function operatorOrEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
     return TFHE.or(lhs, rhs);
-}
-
-using {operatorAndEbool as &, BindingsEbool.and} for ebool global;
-
-function operatorAndEbool(ebool lhs, ebool  rhs) pure returns (ebool) {
-    return TFHE.and(lhs, rhs);
 }
 
 using {operatorAndEuint8 as &, BindingsEuint8.and} for euint8 global;
@@ -3168,8 +2824,6 @@ function operatorAndEuint32(euint32 lhs, euint32  rhs) pure returns (euint32) {
 
 // ********** BINDING DEFS ************* //
 
-using {BindingsEbool.eq} for ebool global;
-
 using {BindingsEuint8.eq} for euint8 global;
 
 library BindingsEuint8 {
@@ -3185,7 +2839,7 @@ function div(euint8 lhs, euint8  rhs) pure internal returns (euint8) {
 function sub(euint8 lhs, euint8  rhs) pure internal returns (euint8) {
     return TFHE.sub(lhs, rhs);
 }
-function eq(euint8 lhs, euint8  rhs) pure internal returns (euint8) {
+function eq(euint8 lhs, euint8  rhs) pure internal returns (ebool) {
     return TFHE.eq(lhs, rhs);
 }
 function and(euint8 lhs, euint8  rhs) pure internal returns (euint8) {
@@ -3210,7 +2864,7 @@ function div(euint16 lhs, euint16  rhs) pure internal returns (euint16) {
 function sub(euint16 lhs, euint16  rhs) pure internal returns (euint16) {
     return TFHE.sub(lhs, rhs);
 }
-function eq(euint16 lhs, euint16  rhs) pure internal returns (euint16) {
+function eq(euint16 lhs, euint16  rhs) pure internal returns (ebool) {
     return TFHE.eq(lhs, rhs);
 }
 function and(euint16 lhs, euint16  rhs) pure internal returns (euint16) {
@@ -3235,7 +2889,7 @@ function div(euint32 lhs, euint32  rhs) pure internal returns (euint32) {
 function sub(euint32 lhs, euint32  rhs) pure internal returns (euint32) {
     return TFHE.sub(lhs, rhs);
 }
-function eq(euint32 lhs, euint32  rhs) pure internal returns (euint32) {
+function eq(euint32 lhs, euint32  rhs) pure internal returns (ebool) {
     return TFHE.eq(lhs, rhs);
 }
 function and(euint32 lhs, euint32  rhs) pure internal returns (euint32) {

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -1340,7 +1340,7 @@ function and(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function and(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function and(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1348,10 +1348,10 @@ function and(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function and(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1359,10 +1359,10 @@ function and(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function and(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1370,10 +1370,10 @@ function and(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function and(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1381,10 +1381,10 @@ function and(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function and(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1392,10 +1392,10 @@ function and(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function and(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1403,10 +1403,10 @@ function and(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function and(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1414,10 +1414,10 @@ function and(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function and(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1425,10 +1425,10 @@ function and(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function and(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1436,10 +1436,10 @@ function and(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function and(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1447,10 +1447,10 @@ function and(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function and(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1458,10 +1458,10 @@ function and(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function and(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1469,10 +1469,10 @@ function and(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function and(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1480,10 +1480,10 @@ function and(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function and(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1491,10 +1491,10 @@ function and(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function and(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function and(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1502,7 +1502,7 @@ function and(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).and);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function or(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -1516,7 +1516,7 @@ function or(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function or(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function or(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1524,10 +1524,10 @@ function or(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function or(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1535,10 +1535,10 @@ function or(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function or(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1546,10 +1546,10 @@ function or(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function or(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1557,10 +1557,10 @@ function or(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function or(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1568,10 +1568,10 @@ function or(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function or(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1579,10 +1579,10 @@ function or(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function or(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1590,10 +1590,10 @@ function or(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function or(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1601,10 +1601,10 @@ function or(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function or(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1612,10 +1612,10 @@ function or(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function or(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1623,10 +1623,10 @@ function or(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function or(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1634,10 +1634,10 @@ function or(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function or(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1645,10 +1645,10 @@ function or(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function or(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1656,10 +1656,10 @@ function or(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function or(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1667,10 +1667,10 @@ function or(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function or(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function or(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1678,7 +1678,7 @@ function or(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).or);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function xor(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -1692,7 +1692,7 @@ function xor(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function xor(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function xor(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1700,10 +1700,10 @@ function xor(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function xor(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1711,10 +1711,10 @@ function xor(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function xor(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1722,10 +1722,10 @@ function xor(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function xor(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1733,10 +1733,10 @@ function xor(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function xor(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1744,10 +1744,10 @@ function xor(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function xor(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1755,10 +1755,10 @@ function xor(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function xor(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1766,10 +1766,10 @@ function xor(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function xor(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1777,10 +1777,10 @@ function xor(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function xor(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1788,10 +1788,10 @@ function xor(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function xor(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1799,10 +1799,10 @@ function xor(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function xor(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1810,10 +1810,10 @@ function xor(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function xor(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1821,10 +1821,10 @@ function xor(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function xor(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1832,10 +1832,10 @@ function xor(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function xor(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1843,10 +1843,10 @@ function xor(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function xor(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function xor(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1854,7 +1854,7 @@ function xor(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).xor);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function eq(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -1868,7 +1868,7 @@ function eq(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function eq(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function eq(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1876,10 +1876,10 @@ function eq(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function eq(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1887,10 +1887,10 @@ function eq(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function eq(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1898,10 +1898,10 @@ function eq(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function eq(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1909,10 +1909,10 @@ function eq(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function eq(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1920,10 +1920,10 @@ function eq(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function eq(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1931,10 +1931,10 @@ function eq(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function eq(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1942,10 +1942,10 @@ function eq(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function eq(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1953,10 +1953,10 @@ function eq(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function eq(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1964,10 +1964,10 @@ function eq(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function eq(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1975,10 +1975,10 @@ function eq(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function eq(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1986,10 +1986,10 @@ function eq(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function eq(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -1997,10 +1997,10 @@ function eq(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function eq(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2008,10 +2008,10 @@ function eq(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function eq(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2019,10 +2019,10 @@ function eq(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function eq(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function eq(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2030,7 +2030,7 @@ function eq(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).eq);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function ne(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2044,7 +2044,7 @@ function ne(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function ne(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function ne(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2052,10 +2052,10 @@ function ne(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function ne(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2063,10 +2063,10 @@ function ne(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function ne(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2074,10 +2074,10 @@ function ne(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function ne(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2085,10 +2085,10 @@ function ne(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function ne(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2096,10 +2096,10 @@ function ne(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function ne(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2107,10 +2107,10 @@ function ne(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function ne(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2118,10 +2118,10 @@ function ne(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function ne(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2129,10 +2129,10 @@ function ne(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function ne(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2140,10 +2140,10 @@ function ne(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function ne(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2151,10 +2151,10 @@ function ne(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function ne(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2162,10 +2162,10 @@ function ne(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function ne(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2173,10 +2173,10 @@ function ne(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function ne(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2184,10 +2184,10 @@ function ne(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function ne(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2195,10 +2195,10 @@ function ne(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function ne(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function ne(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2206,7 +2206,7 @@ function ne(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).ne);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function min(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2220,7 +2220,7 @@ function min(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function min(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function min(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2228,10 +2228,10 @@ function min(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function min(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2239,10 +2239,10 @@ function min(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function min(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2250,10 +2250,10 @@ function min(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function min(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2261,10 +2261,10 @@ function min(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function min(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2272,10 +2272,10 @@ function min(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function min(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2283,10 +2283,10 @@ function min(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function min(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2294,10 +2294,10 @@ function min(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function min(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2305,10 +2305,10 @@ function min(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function min(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2316,10 +2316,10 @@ function min(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function min(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2327,10 +2327,10 @@ function min(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function min(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2338,10 +2338,10 @@ function min(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function min(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2349,10 +2349,10 @@ function min(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function min(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2360,10 +2360,10 @@ function min(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function min(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2371,10 +2371,10 @@ function min(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function min(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function min(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2382,7 +2382,7 @@ function min(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).min);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function max(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2396,7 +2396,7 @@ function max(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function max(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function max(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2404,10 +2404,10 @@ function max(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function max(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2415,10 +2415,10 @@ function max(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function max(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2426,10 +2426,10 @@ function max(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function max(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2437,10 +2437,10 @@ function max(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function max(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2448,10 +2448,10 @@ function max(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function max(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2459,10 +2459,10 @@ function max(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function max(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2470,10 +2470,10 @@ function max(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function max(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2481,10 +2481,10 @@ function max(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function max(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2492,10 +2492,10 @@ function max(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function max(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2503,10 +2503,10 @@ function max(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function max(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2514,10 +2514,10 @@ function max(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function max(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2525,10 +2525,10 @@ function max(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function max(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2536,10 +2536,10 @@ function max(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function max(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2547,10 +2547,10 @@ function max(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function max(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function max(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2558,7 +2558,7 @@ function max(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).max);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function shl(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2572,7 +2572,7 @@ function shl(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function shl(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function shl(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2580,10 +2580,10 @@ function shl(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function shl(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2591,10 +2591,10 @@ function shl(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function shl(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2602,10 +2602,10 @@ function shl(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function shl(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2613,10 +2613,10 @@ function shl(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function shl(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2624,10 +2624,10 @@ function shl(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function shl(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2635,10 +2635,10 @@ function shl(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function shl(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2646,10 +2646,10 @@ function shl(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function shl(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2657,10 +2657,10 @@ function shl(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function shl(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2668,10 +2668,10 @@ function shl(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function shl(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2679,10 +2679,10 @@ function shl(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function shl(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2690,10 +2690,10 @@ function shl(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function shl(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2701,10 +2701,10 @@ function shl(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function shl(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2712,10 +2712,10 @@ function shl(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function shl(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2723,10 +2723,10 @@ function shl(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shl(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function shl(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2734,7 +2734,7 @@ function shl(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shl);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function shr(ebool lhs, ebool rhs) internal pure returns (ebool) {
@@ -2748,7 +2748,7 @@ function shr(ebool lhs, ebool rhs) internal pure returns (ebool) {
     return ebool.wrap(result);
 
 }
-function shr(ebool lhs, euint8 rhs) internal pure returns (euint8) {
+function shr(ebool lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2756,10 +2756,10 @@ function shr(ebool lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(ebool lhs, euint16 rhs) internal pure returns (euint16) {
+function shr(ebool lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2767,10 +2767,10 @@ function shr(ebool lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(ebool lhs, euint32 rhs) internal pure returns (euint32) {
+function shr(ebool lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2778,10 +2778,10 @@ function shr(ebool lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = ebool.unwrap(asEbool(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint8 lhs, ebool rhs) internal pure returns (euint8) {
+function shr(euint8 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2789,10 +2789,10 @@ function shr(euint8 lhs, ebool rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
+function shr(euint8 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2800,10 +2800,10 @@ function shr(euint8 lhs, euint8 rhs) internal pure returns (euint8) {
     uint256 unwrappedInput2 = euint8.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
+function shr(euint8 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2811,10 +2811,10 @@ function shr(euint8 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
+function shr(euint8 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2822,10 +2822,10 @@ function shr(euint8 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint8.unwrap(asEuint8(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint16 lhs, ebool rhs) internal pure returns (euint16) {
+function shr(euint16 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2833,10 +2833,10 @@ function shr(euint16 lhs, ebool rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
+function shr(euint16 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2844,10 +2844,10 @@ function shr(euint16 lhs, euint8 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
+function shr(euint16 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2855,10 +2855,10 @@ function shr(euint16 lhs, euint16 rhs) internal pure returns (euint16) {
     uint256 unwrappedInput2 = euint16.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
+function shr(euint16 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2866,10 +2866,10 @@ function shr(euint16 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint16.unwrap(asEuint16(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint32 lhs, ebool rhs) internal pure returns (euint32) {
+function shr(euint32 lhs, ebool rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2877,10 +2877,10 @@ function shr(euint32 lhs, ebool rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
+function shr(euint32 lhs, euint8 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2888,10 +2888,10 @@ function shr(euint32 lhs, euint8 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
+function shr(euint32 lhs, euint16 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2899,10 +2899,10 @@ function shr(euint32 lhs, euint16 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(asEuint32(rhs));
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
-function shr(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
+function shr(euint32 lhs, euint32 rhs) internal pure returns (ebool) {
     if(!isInitialized(lhs) || !isInitialized(rhs)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2910,7 +2910,7 @@ function shr(euint32 lhs, euint32 rhs) internal pure returns (euint32) {
     uint256 unwrappedInput2 = euint32.unwrap(rhs);
 
     uint256 result = mathHelper(unwrappedInput1, unwrappedInput2, FheOps(Precompiles.Fheos).shr);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 
 }
 function not(ebool input1) internal pure  returns (ebool) {
@@ -2924,7 +2924,7 @@ function not(ebool input1) internal pure  returns (ebool) {
     return ebool.wrap(result);
 }
 
-function not(euint8 input1) internal pure  returns (euint8) {
+function not(euint8 input1) internal pure  returns (ebool) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2932,10 +2932,10 @@ function not(euint8 input1) internal pure  returns (euint8) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return euint8.wrap(result);
+    return ebool.wrap(result);
 }
 
-function not(euint16 input1) internal pure  returns (euint16) {
+function not(euint16 input1) internal pure  returns (ebool) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2943,10 +2943,10 @@ function not(euint16 input1) internal pure  returns (euint16) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return euint16.wrap(result);
+    return ebool.wrap(result);
 }
 
-function not(euint32 input1) internal pure  returns (euint32) {
+function not(euint32 input1) internal pure  returns (ebool) {
     if(!isInitialized(input1)) {
         revert("One or more inputs are not initialized.");
     }
@@ -2954,13 +2954,10 @@ function not(euint32 input1) internal pure  returns (euint32) {
     bytes memory inputAsBytes = bytes.concat(bytes32(unwrappedInput1));
     bytes memory b = FheOps(Precompiles.Fheos).not(inputAsBytes);
     uint256 result = Impl.getValue(b);
-    return euint32.wrap(result);
+    return ebool.wrap(result);
 }
 
 // ********** TYPE CASTING ************* //
-function asEbool(ebool value) internal pure returns (ebool) {
-        return ebool.wrap(Impl.cast(ebool.unwrap(value), Common.ebool_tfhe_go));
-    }
 function asEuint8(ebool value) internal pure returns (euint8) {
         return euint8.wrap(Impl.cast(ebool.unwrap(value), Common.euint8_tfhe_go));
     }
@@ -2972,9 +2969,6 @@ function asEuint32(ebool value) internal pure returns (euint32) {
     }
 function asEbool(euint8 value) internal pure returns (ebool) {
         return ebool.wrap(Impl.cast(euint8.unwrap(value), Common.ebool_tfhe_go));
-    }
-function asEuint8(euint8 value) internal pure returns (euint8) {
-        return euint8.wrap(Impl.cast(euint8.unwrap(value), Common.euint8_tfhe_go));
     }
 function asEuint16(euint8 value) internal pure returns (euint16) {
         return euint16.wrap(Impl.cast(euint8.unwrap(value), Common.euint16_tfhe_go));
@@ -2988,9 +2982,6 @@ function asEbool(euint16 value) internal pure returns (ebool) {
 function asEuint8(euint16 value) internal pure returns (euint8) {
         return euint8.wrap(Impl.cast(euint16.unwrap(value), Common.euint8_tfhe_go));
     }
-function asEuint16(euint16 value) internal pure returns (euint16) {
-        return euint16.wrap(Impl.cast(euint16.unwrap(value), Common.euint16_tfhe_go));
-    }
 function asEuint32(euint16 value) internal pure returns (euint32) {
         return euint32.wrap(Impl.cast(euint16.unwrap(value), Common.euint32_tfhe_go));
     }
@@ -3002,9 +2993,6 @@ function asEuint8(euint32 value) internal pure returns (euint8) {
     }
 function asEuint16(euint32 value) internal pure returns (euint16) {
         return euint16.wrap(Impl.cast(euint32.unwrap(value), Common.euint16_tfhe_go));
-    }
-function asEuint32(euint32 value) internal pure returns (euint32) {
-        return euint32.wrap(Impl.cast(euint32.unwrap(value), Common.euint32_tfhe_go));
     }
 function asEbool(uint256 value) internal pure returns (ebool) {
         return ebool.wrap(Impl.trivialEncrypt(value, Common.ebool_tfhe_go));


### PR DESCRIPTION
- solgen: Don't support math operations on ebool
- solgen: force asEbool to use ne
- solgen: remove "as" functions that receive the same type
- solgen: All comparison operations (eq, ne, gt, lt, etc.) should only return Ebool

https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1338276170
https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1339695449
https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1339695814
https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1339711645