### PR TITLE
logs format

### DIFF
--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -181,7 +181,7 @@ func SealOutput(utype byte, ctHash []byte, pk []byte, tp *TxParams) ([]byte, uin
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
-	logger.Debug(functionName+"success", "ciphertext-hash ", hex.EncodeToString(ctHash), "public-key", hex.EncodeToString(pk))
+	logger.Debug(functionName+" success", "ciphertext-hash ", hex.EncodeToString(ctHash), "public-key", hex.EncodeToString(pk))
 
 	return reencryptedValue, gas, nil
 }

--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -70,7 +70,7 @@ func Add(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+": Inputs not verified", "err", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -121,9 +121,7 @@ func Verify(utype byte, input []byte, tp *TxParams) ([]byte, uint64, error) {
 
 	ct, err := tfhe.NewCipherTextFromBytes(input, uintType, true /* TODO: not sure + shouldn't be hardcoded */)
 	if err != nil {
-		logger.Error(functionName, " failed to deserialize input ciphertext",
-			" err ", err,
-			" len ", len(input))
+		logger.Error(functionName+" failed to deserialize input ciphertext", "err", err, "len", len(input))
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -160,30 +158,30 @@ func SealOutput(utype byte, ctHash []byte, pk []byte, tp *TxParams) ([]byte, uin
 
 	if len(ctHash) != 32 {
 		msg := functionName + " ciphertext's hashes need to be 32 bytes long"
-		logger.Error(msg, " ciphertxt's hash is: ", hex.EncodeToString(ctHash), " of len ", len(ctHash))
+		logger.Error(msg, "ciphertext-hash", hex.EncodeToString(ctHash), "hash-len", len(ctHash))
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if len(pk) != 32 {
 		msg := functionName + " public key need to be 32 bytes long"
-		logger.Error(msg, " public key is: ", hex.EncodeToString(pk), " of len ", len(pk))
+		logger.Error(msg, "public-key", hex.EncodeToString(pk), "len", len(pk))
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	ct := getCiphertext(state, tfhe.BytesToHash(ctHash))
 	if ct == nil {
 		msg := functionName + " unverified ciphertext handle"
-		logger.Error(msg, " ciphertext's hash: ", hex.EncodeToString(ctHash))
+		logger.Error(msg, "ciphertext-hash", hex.EncodeToString(ctHash))
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	reencryptedValue, err := tfhe.SealOutput(*ct, pk)
 	if err != nil {
-		logger.Error(functionName, " failed to encrypt to user key", " err ", err)
+		logger.Error(functionName+" failed to encrypt to user key", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
-	logger.Debug(functionName+" success", "ciphertext-hash ", hex.EncodeToString(ctHash), "public-key", hex.EncodeToString(pk))
+	logger.Debug(functionName+"success", "ciphertext-hash ", hex.EncodeToString(ctHash), "public-key", hex.EncodeToString(pk))
 
 	return reencryptedValue, gas, nil
 }
@@ -210,7 +208,7 @@ func Decrypt(utype byte, input []byte, tp *TxParams) (*big.Int, uint64, error) {
 
 	if len(input) != 32 {
 		msg := functionName + " input len must be 32 bytes"
-		logger.Error(msg, " input ", hex.EncodeToString(input), " len ", len(input))
+		logger.Error(msg, "input", hex.EncodeToString(input), "len", len(input))
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -223,7 +221,7 @@ func Decrypt(utype byte, input []byte, tp *TxParams) (*big.Int, uint64, error) {
 
 	decryptedValue, err := tfhe.Decrypt(*ct)
 	if err != nil {
-		logger.Error("failed decrypting ciphertext", " error ", err)
+		logger.Error("failed decrypting ciphertext", "error", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -255,13 +253,13 @@ func Lte(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -303,19 +301,19 @@ func Sub(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Sub(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -351,19 +349,19 @@ func Mul(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Mul(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -400,19 +398,19 @@ func Lt(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint6
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Lt(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+"  failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -448,7 +446,7 @@ func Select(utype byte, controlHash []byte, ifTrueHash []byte, ifFalseHash []byt
 
 	control, ifTrue, ifFalse, err := get3VerifiedOperands(state, controlHash, ifTrueHash, ifFalseHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified control len: ", len(controlHash), " ifTrue len: ", len(ifTrueHash), " ifFalse len: ", len(ifFalseHash), " err: ", err)
+		logger.Error(functionName+": inputs not verified control len: ", len(controlHash), " ifTrue len: ", len(ifTrueHash), " ifFalse len: ", len(ifFalseHash), " err: ", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -649,19 +647,19 @@ func Div(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Div(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -699,19 +697,19 @@ func Gt(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint6
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName, " inputs not verified", " err ", err)
+		logger.Error(functionName+": inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Gt(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -749,19 +747,19 @@ func Gte(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Gte(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -797,19 +795,19 @@ func Rem(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Rem(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -846,19 +844,19 @@ func And(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.And(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -896,19 +894,19 @@ func Or(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint6
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Or(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -946,19 +944,19 @@ func Xor(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Xor(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -996,19 +994,19 @@ func Eq(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint6
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Eq(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1046,19 +1044,19 @@ func Ne(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint6
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Ne(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1094,19 +1092,19 @@ func Min(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Min(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1142,19 +1140,19 @@ func Max(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Max(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1190,19 +1188,19 @@ func Shl(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Shl(rhs)
 	if err != nil {
-		logger.Error(functionName+" failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1238,19 +1236,19 @@ func Shr(utype byte, lhsHash []byte, rhsHash []byte, tp *TxParams) ([]byte, uint
 
 	lhs, rhs, err := get2VerifiedOperands(state, lhsHash, rhsHash)
 	if err != nil {
-		logger.Error(functionName+" inputs not verified", " err ", err)
+		logger.Error(functionName+" inputs not verified", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	if lhs.UintType != rhs.UintType {
 		msg := functionName + " operand type mismatch"
-		logger.Error(msg, " lhs ", lhs.UintType, " rhs ", rhs.UintType)
+		logger.Error(msg, "lhs", lhs.UintType, "rhs", rhs.UintType)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
 	result, err := lhs.Shr(rhs)
 	if err != nil {
-		logger.Error(functionName, " failed", " err ", err)
+		logger.Error(functionName+" failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 	err = importCiphertext(state, result)
@@ -1293,7 +1291,7 @@ func Not(utype byte, value []byte, tp *TxParams) ([]byte, uint64, error) {
 
 	result, err := ct.Not()
 	if err != nil {
-		logger.Error("not failed", " err ", err)
+		logger.Error("not failed", "err", err)
 		return nil, 0, vm.ErrExecutionReverted
 	}
 
@@ -1317,7 +1315,7 @@ func GetNetworkPublicKey(tp *TxParams) ([]byte, error) {
 
 	pk, err := tfhe.PublicKey()
 	if err != nil {
-		logger.Error("could not get public key", " err ", err)
+		logger.Error("could not get public key", "err", err)
 		return nil, vm.ErrExecutionReverted
 	}
 

--- a/precompiles/state.go
+++ b/precompiles/state.go
@@ -46,7 +46,7 @@ func createFheosState(storage *Storage, version uint64) error {
 	for i := 0; i < 3; i++ {
 		ezero[i], _, err = TrivialEncrypt(zero, byte(i), &tempTp)
 		if err != nil {
-			logger.Error("failed to encrypt 0 for ezero ", i, err)
+			logger.Error("failed to encrypt 0 for ezero", "toType", i, "err", err)
 			return err
 		}
 	}
@@ -66,14 +66,14 @@ func InitializeFheosState() error {
 
 	err := storage.PutVersion(FheosVersion)
 	if err != nil {
-		logger.Error("failed to write version into fheos db ", err)
+		logger.Error("failed to write version into fheos db", "err", err)
 		return errors.New("failed to write version into fheos db")
 	}
 
 	err = createFheosState(&storage, FheosVersion)
 
 	if err != nil {
-		logger.Error("failed to create fheos state ", err)
+		logger.Error("failed to create fheos state", "err", err)
 		return errors.New("failed to create fheos state")
 	}
 

--- a/precompiles/storage.go
+++ b/precompiles/storage.go
@@ -47,7 +47,7 @@ func (store LevelDbStorage) OpenDB(readonly bool) *leveldb.DB {
 
 	db, err := leveldb.OpenFile(store.dbPath, &opt.Options{ReadOnly: readonly})
 	if err != nil {
-		logger.Error("failed to open fheos db ", err)
+		logger.Error("failed to open fheos db", "err", err)
 		panic(err)
 	}
 
@@ -63,7 +63,7 @@ func closeDB(db *leveldb.DB, readonly bool) {
 
 	err := db.Close()
 	if err != nil {
-		logger.Error("failed to close fheos db ", err)
+		logger.Error("failed to close fheos db", "err", err)
 		panic(err)
 	}
 
@@ -79,7 +79,7 @@ func (store LevelDbStorage) Put(t DataType, key []byte, val []byte) error {
 
 	err := db.Put(extendedKey, val, nil)
 	if err != nil {
-		logger.Error("failed to write into fheos db ", err)
+		logger.Error("failed to write into fheos db", "err", err)
 		return err
 	}
 
@@ -96,7 +96,7 @@ func (store LevelDbStorage) Get(t DataType, key []byte) ([]byte, error) {
 
 	val, err := db.Get(extendedKey, nil)
 	if err != nil {
-		logger.Error("failed to read from fheos db ", err)
+		logger.Error("failed to read from fheos db", "err", err)
 		return nil, err
 	}
 
@@ -124,7 +124,7 @@ func (store LevelDbStorage) PutCt(h tfhe.Hash, cipher *tfhe.Ciphertext) error {
 	enc := gob.NewEncoder(&cipherBuffer)
 	err := enc.Encode(*cipher)
 	if err != nil {
-		logger.Error("failed to encode ciphertext ", err)
+		logger.Error("failed to encode ciphertext", "err", err)
 		return err
 	}
 
@@ -141,7 +141,7 @@ func (store LevelDbStorage) GetCt(h tfhe.Hash) (*tfhe.Ciphertext, error) {
 	dec := gob.NewDecoder(bytes.NewReader(v))
 	err = dec.Decode(&cipher)
 	if err != nil {
-		logger.Error("failed to decode ciphertext ", err)
+		logger.Error("failed to decode ciphertext", "err", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Formatted logs according to 'log' ethereum package's interface.
Replaced
`log.Error(msgs...)`
with
`log.Error(msg, [key, value]...)`

Otherwise this would happen:
![image](https://github.com/FhenixProtocol/fheos/assets/98821241/0b7fa30f-677b-4dc6-b72a-7c6c9f556058)

nitro: https://github.com/FhenixProtocol/nitro/pull/62
