### PR TITLE
enabled nitro process reading env variables

### DIFF
--- a/deployment/run.sh
+++ b/deployment/run.sh
@@ -12,4 +12,13 @@ sleep 3
 
 node faucet/server.js &
 
-nitro --conf.file /config/sequencer_config.json --metrics --node.feed.output.enable --node.feed.output.port 9642  --http.api net,web3,eth,txpool,debug --node.seq-coordinator.my-url  ws://sequencer:8548 --graphql.enable --graphql.vhosts "*" --graphql.corsdomain "*"
+nitro --conf.file /config/sequencer_config.json \
+    --metrics \
+    --node.feed.output.enable \
+    --node.feed.output.port 9642 \
+    --http.api net,web3,eth,txpool,debug \
+    --node.seq-coordinator.my-url ws://sequencer:8548 \
+    --graphql.enable \
+    --graphql.vhosts "*" \
+    --graphql.corsdomain "*" \
+    --conf.env-prefix "NITRO"


### PR DESCRIPTION
You can configure the log level of the nitro process via the `log-level` koanf flag.
This could be loaded via a command-line flag, a configuration file, or an environment variable.
I [though](https://github.com/FhenixProtocol/fheos/pull/57#issuecomment-1903536762) the environment variable would be the easiest way to set on the localfhenix docker, as you should just pass it on `docker run -e VAR=x localfhenix`.
For the other two methods, you have to start changing config files.
Problem is, it turns out that env variables are disabled unless the `conf.env-prefix` is specified.
So I populated that field in the `run.sh` with the prefix `NITRO_`.
Now we can set any configuration via the environment variables, replacing `.` with `_` and `-` with `__`.

So, to set the `log-level` field (on the image that will eventually be built with this change included),
`docker run -e NITRO_LOG__LEVEL=2 localfhenix`
log levels in our current go-ethereum/log (this changes in later versions of go-ethereum):
	LvlCrit 0
	LvlError 1
	LvlWarn 2
	LvlInfo 3 (default)
	LvlDebug 4
	LvlTrace 5
	
Note that there will still be INFO messages shown of the other processes that run inside the docker, namely the faucet, fhe-engine-server, and fheos init-state

until this localfhenix is created, you can edit run.sh and add the `--log-level x` flag to the process, and pass the run.sh to the container via `-v ./run.sh:/home/user/run.sh` 