### PR TITLE
Test unary op on new security zone

### DIFF
--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -700,7 +700,7 @@ func TrivialEncrypt(input []byte, toType byte, securityZone int32, tp *TxParams)
 	}
 
 	if shouldPrintPrecompileInfo(tp) {
-		logger.Debug(functionName.String()+" success", "contractAddress", tp.ContractAddress, "ctHash", ctHash.Hex(), "valueToEncrypt", valueToEncrypt.Uint64())
+		logger.Debug(functionName.String()+" success", "contractAddress", tp.ContractAddress, "ctHash", ctHash.Hex(), "valueToEncrypt", valueToEncrypt.Uint64(), "securityZone", ct.SecurityZone)
 	}
 	return ctHash[:], gas, nil
 }

--- a/solgen/common.ts
+++ b/solgen/common.ts
@@ -25,6 +25,9 @@ const patternAllowedOperationsEuint256 =   ["ne|eq|sealoutput|select|seal|decryp
 const patternAllowedOperationsEaddress =   ["ne|^eq$|sealoutput|select|seal|decrypt"];
 /*------------------------------------------------------------*/
 
+// Although casts from eaddress to types with < 256 bits are possible, we don't want to test them.
+export const AllowedTypesOnCastToEaddress = ["euint256", "uint256", "inEaddress", "bytes memory", "address"]
+
 export const AllowedOperations = [
   patternAllowedOperationsEbool,
   patternAllowedOperationsEuint8,

--- a/solgen/solgen.ts
+++ b/solgen/solgen.ts
@@ -428,7 +428,7 @@ const main = async () => {
       outputFile += AsTypeFunction(fromType, toType);
     }
   }
-  // (Hardcoded) For a better UX we need to be able to cast address to eaddress, the following line does so:
+  // For a better UX, allow casting from address to eaddress:
   outputFile += AsTypeFunction('address', 'eaddress')
   
   for (let type of EInputType) {

--- a/solgen/templates/benchContracts.ts
+++ b/solgen/templates/benchContracts.ts
@@ -6,7 +6,7 @@ import {
   toInType,
   toInTypeParam,
   toVarSuffix,
-  toAsType,
+  toAsType, AllowedTypesOnCastToEaddress,
 } from "../common";
 
 const IsOperationAllowed = (
@@ -175,9 +175,8 @@ export function AsTypeBenchmarkContract(type: string) {
   let loads = "";
   let casts = "";
 
-  // Although casts from eaddress to types with < 256 bits are possible, we don't want to bench them.
-  let eaddressAllowedTypes = ["euint256"];
-  let fromTypeCollection = type === "eaddress" ? eaddressAllowedTypes : EInputType;
+  const eaddressTypes = AllowedTypesOnCastToEaddress.filter(t => t.startsWith("e")); // filter out built-in-types which we deal with explicitly
+  let fromTypeCollection = type === "eaddress" ? eaddressTypes : EInputType;
 
   for (let fromType of fromTypeCollection) {
     if (fromType === type) {

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -299,24 +299,23 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
     /// @return a ciphertext representation of the input`;
     addSecurityZone = true;
     castString = castFromBytes("value", toType);
-  } else if (fromType == "address" && toType == "eaddress") {
-    docString += `
-    /// Allows for a better user experience when working with eaddresses`;
-    if (!addSecurityZone) {
-      // recursive call to add the asType override with the security zone
-      overrideFuncs += AsTypeFunction(fromType, toType, true);
-    } else {
-      docString += `, specifying security zone`;
-    }
-    castString = castFromAddress("value", toType, addSecurityZone);
   } else if (EPlaintextType.includes(fromType)) {
+    docString += `
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation`;
+
     if (!addSecurityZone) {
       // recursive call to add the asType override with the security zone
       overrideFuncs += AsTypeFunction(fromType, toType, true);
     } else {
       docString += `, specifying security zone`;
     }
-    castString = castFromPlaintext("value", toType, addSecurityZone);
+    if (toType == "eaddress") {
+      docString += `
+    /// Allows for a better user experience when working with eaddresses`;
+      castString = castFromAddress("value", toType, addSecurityZone);
+    } else {
+      castString = castFromPlaintext("value", toType, addSecurityZone);
+    }
   } else if (toType === "ebool") {
     return castToEbool("value", fromType);
   } else if (!EInputType.includes(fromType)) {

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -241,6 +241,8 @@ const castFromInputType = (name: string, toType: string): string => {
 };
 
 const castToEbool = (name: string, fromType: string): string => {
+  // todo (eshel): this should not work for non-default security zones because the second operand of the 'ne' is always from security zone 0.
+  // check if the precompiles support the EBOOL_TFHE constant as with the other casts
   return `
     \n    /// @notice Converts a ${fromType} to an ebool
     function asEbool(${fromType} value) internal pure returns (ebool) {
@@ -258,16 +260,24 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
   if (fromType === "bool" && toType === "ebool") {
     return `
     /// @notice Converts a plaintext boolean value to a ciphertext ebool
-    /// @dev Privacy: The input value is public, therefore the ciphertext should be considered public and should be used
-    ///only for mathematical operations, not to represent data that should be private
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     /// @return A ciphertext representation of the input 
     function asEbool(bool value) internal pure returns (ebool) {
         uint256 sVal = 0;
         if (value) {
             sVal = 1;
         }
-
         return asEbool(sVal);
+    }
+    /// @notice Converts a plaintext boolean value to a ciphertext ebool, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
+    /// @return A ciphertext representation of the input 
+    function asEbool(bool value, int32 securityZone) internal pure returns (ebool) {
+      uint256 sVal = 0;
+      if (value) {
+        sVal = 1;
+      }
+      return asEbool(sVal, securityZone);
     }`;
   } else if (fromType.startsWith("inE")) {
     docString = `

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -228,7 +228,7 @@ const castFromPlaintext = (name: string, toType: string, addSecurityZone: boolea
   return `Impl.trivialEncrypt(${name}, Common.${toType.toUpperCase()}_TFHE, ${addSecurityZone ? "securityZone" : "0"})`;
 };
 
-const castFromAddress = (name: string, toType: string, addSecurityZone: boolean = false): string => {
+const castFromPlaintextAddress = (name: string, toType: string, addSecurityZone: boolean = false): string => {
   return `Impl.trivialEncrypt(uint256(uint160(${name})), Common.${toType.toUpperCase()}_TFHE, ${addSecurityZone ? "securityZone" : "0"})`;
 };
 
@@ -261,7 +261,7 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
     return `
     /// @notice Converts a plaintext boolean value to a ciphertext ebool
     /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
-    /// @return A ciphertext representation of the input 
+    /// @return A ciphertext representation of the input
     function asEbool(bool value) internal pure returns (ebool) {
         uint256 sVal = 0;
         if (value) {
@@ -271,7 +271,7 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
     }
     /// @notice Converts a plaintext boolean value to a ciphertext ebool, specifying security zone
     /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
-    /// @return A ciphertext representation of the input 
+    /// @return A ciphertext representation of the input
     function asEbool(bool value, int32 securityZone) internal pure returns (ebool) {
       uint256 sVal = 0;
       if (value) {
@@ -310,10 +310,10 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
     docString += `
     /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation`;
 
-    if (toType == "eaddress") {
+    if (fromType === "address" && toType == "eaddress") {
       docString += `
     /// Allows for a better user experience when working with eaddresses`;
-      castString = castFromAddress("value", toType, addSecurityZone);
+      castString = castFromPlaintextAddress("value", toType, addSecurityZone);
     } else {
       castString = castFromPlaintext("value", toType, addSecurityZone);
     }

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_SEAL_FUNCTION_NAME,
   LOCAL_DECRYPT_FUNCTION_NAME,
   AllowedOperations,
+  AllowedTypesOnCastToEaddress,
   toPlaintextType,
   capitalize,
   shortenType,
@@ -251,6 +252,10 @@ const castToEbool = (name: string, fromType: string): string => {
 };
 
 export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone: boolean = false) => {
+  if (toType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(fromType) ) {
+    return ""; // skip unsupported cast
+  }
+
   let castString = castFromEncrypted(fromType, toType, "value");
   let overrideFuncs = '';
 
@@ -665,6 +670,10 @@ export const OperatorBinding = (
 };
 
 export const CastBinding = (thisType: string, targetType: string) => {
+  if (targetType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(thisType) ) {
+    return ""; // skip unsupported cast
+  }
+
   return `
     function to${shortenType(
       targetType

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -300,15 +300,16 @@ export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone
     addSecurityZone = true;
     castString = castFromBytes("value", toType);
   } else if (EPlaintextType.includes(fromType)) {
-    docString += `
-    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation`;
-
     if (!addSecurityZone) {
       // recursive call to add the asType override with the security zone
       overrideFuncs += AsTypeFunction(fromType, toType, true);
     } else {
       docString += `, specifying security zone`;
     }
+
+    docString += `
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation`;
+
     if (toType == "eaddress") {
       docString += `
     /// Allows for a better user experience when working with eaddresses`;

--- a/solgen/templates/testContracts.ts
+++ b/solgen/templates/testContracts.ts
@@ -265,27 +265,27 @@ export function testContract1Arg(name: string) {
     name,
     EInputType.indexOf("euint256")
   );
-  let func = `function ${name}(string calldata test, uint256 a) public pure returns (uint256 output) {
+  let func = `function ${name}(string calldata test, uint256 a, int32 securityZone) public pure returns (uint256 output) {
         if (Utils.cmp(test, "${name}(euint8)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint8(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint8(a, securityZone)));
         } else if (Utils.cmp(test, "${name}(euint16)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint16(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint16(a, securityZone)));
         } else if (Utils.cmp(test, "${name}(euint32)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint32(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint32(a, securityZone)));
         }`;
   if (isEuint64Allowed) {
     func += ` else if (Utils.cmp(test, "${name}(euint64)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint64(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint64(a, securityZone)));
         }`;
   }
   if (isEuint128Allowed) {
     func += ` else if (Utils.cmp(test, "${name}(euint128)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint128(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint128(a, securityZone)));
         }`;
   }
   if (isEuint256Allowed) {
     func += ` else if (Utils.cmp(test, "${name}(euint256)")) {
-            return FHE.decrypt(FHE.${name}(FHE.asEuint256(a)));
+            return FHE.decrypt(FHE.${name}(FHE.asEuint256(a, securityZone)));
         }`;
   }
   func += ` else if (Utils.cmp(test, "${name}(ebool)")) {
@@ -294,7 +294,7 @@ export function testContract1Arg(name: string) {
                 aBool = false;
             }
 
-            if (FHE.decrypt(FHE.${name}(FHE.asEbool(aBool)))) {
+            if (FHE.decrypt(FHE.${name}(FHE.asEbool(aBool, securityZone)))) {
                 return 1;
             }
 

--- a/solgen/templates/testContracts.ts
+++ b/solgen/templates/testContracts.ts
@@ -4,8 +4,11 @@ import {
   SEAL_RETURN_TYPE,
   LOCAL_SEAL_FUNCTION_NAME,
   AllowedOperations,
+  AllowedTypesOnCastToEaddress,
   capitalize,
-  shortenType, toInType, toInTypeParam,
+  shortenType,
+  toInType,
+  toInTypeParam,
 } from "../common";
 
 function TypeCastTestingFunction(
@@ -16,9 +19,13 @@ function TypeCastTestingFunction(
 ) {
   let to = capitalize(toType);
   const retType = to.slice(1);
+
   let testType = fromTypeEncrypted ? fromTypeEncrypted : fromType;
-  testType = testType.startsWith("inE") ? "PreEncrypted" : capitalize(testType);
-  testType = testType === "Uint256" ? "Plaintext" : testType;
+  testType = testType === "uint256" ? "Plaintext" : testType;
+  testType = testType === "address" ? "PlaintextAddress" : testType;
+  testType = testType.startsWith("inE") ? "PreEncrypted" : testType;
+  testType = capitalize(testType)
+
   const encryptedVal = fromTypeEncrypted
     ? `FHE.as${capitalize(fromTypeEncrypted)}(val)`
     : "val";
@@ -28,7 +35,7 @@ function TypeCastTestingFunction(
   let abi: string;
   let func = "\n\n    ";
 
-  if (testType === "PreEncrypted" || testType === "Plaintext") {
+  if (testType === "PreEncrypted" || testType === "Plaintext" || testType === "PlaintextAddress") {
     func += `function castFrom${testType}To${to}(${fromType} val) public pure returns (${retType}) {
         return FHE.decrypt(FHE.as${to}(${encryptedVal}));
     }`;
@@ -54,18 +61,21 @@ export function AsTypeTestingContract(type: string) {
     type
   )}TestType extends BaseContract {\n`;
 
-  // Although casts from eaddress to types with < 256 bits are possible, we don't want to test them.
-  let eaddressAllowedTypes = ["euint256", "uint256"];
-  let fromTypeCollection = type === "eaddress" ? eaddressAllowedTypes : EInputType.concat("uint256");
+  let typesToEaddres = AllowedTypesOnCastToEaddress
+    .filter(t => t !== "inEaddress")    // added explicitly later
+    .filter(t => t !== "bytes memory"); // tested indirectly via "inEaddress"
+  let fromTypeCollection = type === "eaddress" ? typesToEaddres : EInputType.concat("uint256");
+
+  // add inE(type) calldata
   fromTypeCollection = fromTypeCollection.concat(toInTypeParam(type));
 
   for (const fromType of fromTypeCollection) {
-    if (type === fromType || (fromType === "eaddress" && !eaddressAllowedTypes.includes(type))) {
+    if (type === fromType || (fromType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(type))) {
       continue;
     }
 
     const fromTypeTs = fromType.startsWith("inE") ? "EncryptedNumber" : `bigint`;
-    const fromTypeSol = fromType.startsWith("inE") ? fromType : `uint256`;
+    const fromTypeSol = fromType.startsWith("e") ? `uint256` : fromType;
     const fromTypeEncrypted = EInputType.includes(fromType)
       ? fromType
       : undefined;

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -2533,10 +2533,6 @@ library FHE {
     function asEuint256(ebool value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EBOOL_TFHE, ebool.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a ebool to an eaddress
-    function asEaddress(ebool value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EBOOL_TFHE, ebool.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint8 to an ebool
     function asEbool(euint8 value) internal pure returns (ebool) {
@@ -2567,10 +2563,6 @@ library FHE {
     /// @notice Converts a euint8 to an euint256
     function asEuint256(euint8 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT8_TFHE, euint8.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint8 to an eaddress
-    function asEaddress(euint8 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT8_TFHE, euint8.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint16 to an ebool
@@ -2603,10 +2595,6 @@ library FHE {
     function asEuint256(euint16 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT16_TFHE, euint16.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a euint16 to an eaddress
-    function asEaddress(euint16 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT16_TFHE, euint16.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint32 to an ebool
     function asEbool(euint32 value) internal pure returns (ebool) {
@@ -2637,10 +2625,6 @@ library FHE {
     /// @notice Converts a euint32 to an euint256
     function asEuint256(euint32 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT32_TFHE, euint32.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint32 to an eaddress
-    function asEaddress(euint32 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT32_TFHE, euint32.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint64 to an ebool
@@ -2673,10 +2657,6 @@ library FHE {
     function asEuint256(euint64 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT64_TFHE, euint64.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a euint64 to an eaddress
-    function asEaddress(euint64 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT64_TFHE, euint64.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint128 to an ebool
     function asEbool(euint128 value) internal pure returns (ebool) {
@@ -2707,10 +2687,6 @@ library FHE {
     /// @notice Converts a euint128 to an euint256
     function asEuint256(euint128 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT128_TFHE, euint128.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint128 to an eaddress
-    function asEaddress(euint128 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT128_TFHE, euint128.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint256 to an ebool
@@ -3236,9 +3212,6 @@ library BindingsEbool {
     function toU256(ebool value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(ebool value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(ebool value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3410,9 +3383,6 @@ library BindingsEuint8 {
     }
     function toU256(euint8 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
-    }
-    function toEaddress(euint8 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
     }
     function seal(euint8 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
@@ -3586,9 +3556,6 @@ library BindingsEuint16 {
     function toU256(euint16 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint16 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint16 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3761,9 +3728,6 @@ library BindingsEuint32 {
     function toU256(euint32 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint32 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint32 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3920,9 +3884,6 @@ library BindingsEuint64 {
     function toU256(euint64 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint64 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint64 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -4070,9 +4031,6 @@ library BindingsEuint128 {
     }
     function toU256(euint128 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
-    }
-    function toEaddress(euint128 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
     }
     function seal(euint128 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -2783,66 +2783,82 @@ library FHE {
         return FHE.asEaddress(value.data, value.securityZone);
     }
     /// @notice Converts a uint256 to an ebool
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEbool(uint256 value) internal pure returns (ebool) {
         return ebool.wrap(Impl.trivialEncrypt(value, Common.EBOOL_TFHE, 0));
     }
     /// @notice Converts a uint256 to an ebool, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEbool(uint256 value, int32 securityZone) internal pure returns (ebool) {
         return ebool.wrap(Impl.trivialEncrypt(value, Common.EBOOL_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint8
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint8(uint256 value) internal pure returns (euint8) {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.EUINT8_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint8, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint8(uint256 value, int32 securityZone) internal pure returns (euint8) {
         return euint8.wrap(Impl.trivialEncrypt(value, Common.EUINT8_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint16
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint16(uint256 value) internal pure returns (euint16) {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.EUINT16_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint16, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint16(uint256 value, int32 securityZone) internal pure returns (euint16) {
         return euint16.wrap(Impl.trivialEncrypt(value, Common.EUINT16_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint32
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint32(uint256 value) internal pure returns (euint32) {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.EUINT32_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint32, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint32(uint256 value, int32 securityZone) internal pure returns (euint32) {
         return euint32.wrap(Impl.trivialEncrypt(value, Common.EUINT32_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint64
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint64(uint256 value) internal pure returns (euint64) {
         return euint64.wrap(Impl.trivialEncrypt(value, Common.EUINT64_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint64, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint64(uint256 value, int32 securityZone) internal pure returns (euint64) {
         return euint64.wrap(Impl.trivialEncrypt(value, Common.EUINT64_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint128
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint128(uint256 value) internal pure returns (euint128) {
         return euint128.wrap(Impl.trivialEncrypt(value, Common.EUINT128_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint128, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint128(uint256 value, int32 securityZone) internal pure returns (euint128) {
         return euint128.wrap(Impl.trivialEncrypt(value, Common.EUINT128_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an euint256
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint256(uint256 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.trivialEncrypt(value, Common.EUINT256_TFHE, 0));
     }
     /// @notice Converts a uint256 to an euint256, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEuint256(uint256 value, int32 securityZone) internal pure returns (euint256) {
         return euint256.wrap(Impl.trivialEncrypt(value, Common.EUINT256_TFHE, securityZone));
     }
     /// @notice Converts a uint256 to an eaddress
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEaddress(uint256 value) internal pure returns (eaddress) {
         return eaddress.wrap(Impl.trivialEncrypt(value, Common.EADDRESS_TFHE, 0));
     }
     /// @notice Converts a uint256 to an eaddress, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     function asEaddress(uint256 value, int32 securityZone) internal pure returns (eaddress) {
         return eaddress.wrap(Impl.trivialEncrypt(value, Common.EADDRESS_TFHE, securityZone));
     }
@@ -2895,26 +2911,36 @@ library FHE {
         return eaddress.wrap(Impl.verify(value, Common.EADDRESS_TFHE, securityZone));
     }
     /// @notice Converts a address to an eaddress
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
     /// Allows for a better user experience when working with eaddresses
     function asEaddress(address value) internal pure returns (eaddress) {
         return eaddress.wrap(Impl.trivialEncrypt(uint256(uint160(value)), Common.EADDRESS_TFHE, 0));
     }
-    /// @notice Converts a address to an eaddress
-    /// Allows for a better user experience when working with eaddresses, specifying security zone
+    /// @notice Converts a address to an eaddress, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
+    /// Allows for a better user experience when working with eaddresses
     function asEaddress(address value, int32 securityZone) internal pure returns (eaddress) {
         return eaddress.wrap(Impl.trivialEncrypt(uint256(uint160(value)), Common.EADDRESS_TFHE, securityZone));
     }
     /// @notice Converts a plaintext boolean value to a ciphertext ebool
-    /// @dev Privacy: The input value is public, therefore the ciphertext should be considered public and should be used
-    ///only for mathematical operations, not to represent data that should be private
-    /// @return A ciphertext representation of the input 
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
+    /// @return A ciphertext representation of the input
     function asEbool(bool value) internal pure returns (ebool) {
         uint256 sVal = 0;
         if (value) {
             sVal = 1;
         }
-
         return asEbool(sVal);
+    }
+    /// @notice Converts a plaintext boolean value to a ciphertext ebool, specifying security zone
+    /// @dev Privacy: The input value is public, therefore the resulting ciphertext should be considered public until involved in an fhe operation
+    /// @return A ciphertext representation of the input
+    function asEbool(bool value, int32 securityZone) internal pure returns (ebool) {
+      uint256 sVal = 0;
+      if (value) {
+        sVal = 1;
+      }
+      return asEbool(sVal, securityZone);
     }
 }
 

--- a/solidity/tests/abis.ts
+++ b/solidity/tests/abis.ts
@@ -145,6 +145,7 @@ export interface AsEuint256TestType extends BaseContract {
 export interface AsEaddressTestType extends BaseContract {
     castFromEuint256ToEaddress: (val: bigint, test: string) => Promise<bigint>;
     castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
+    castFromPlaintextAddressToEaddress: (val: bigint) => Promise<bigint>;
     castFromPreEncryptedToEaddress: (val: EncryptedNumber) => Promise<bigint>;
 }
 

--- a/solidity/tests/contracts/Not.sol
+++ b/solidity/tests/contracts/Not.sol
@@ -9,24 +9,24 @@ error TestNotFound(string test);
 contract NotTest {
     using Utils for *;
     
-    function not(string calldata test, uint256 a) public pure returns (uint256 output) {
+    function not(string calldata test, uint256 a, int32 securityZone) public pure returns (uint256 output) {
         if (Utils.cmp(test, "not(euint8)")) {
-            return FHE.decrypt(FHE.not(FHE.asEuint8(a)));
+            return FHE.decrypt(FHE.not(FHE.asEuint8(a, securityZone)));
         } else if (Utils.cmp(test, "not(euint16)")) {
-            return FHE.decrypt(FHE.not(FHE.asEuint16(a)));
+            return FHE.decrypt(FHE.not(FHE.asEuint16(a, securityZone)));
         } else if (Utils.cmp(test, "not(euint32)")) {
-            return FHE.decrypt(FHE.not(FHE.asEuint32(a)));
+            return FHE.decrypt(FHE.not(FHE.asEuint32(a, securityZone)));
         } else if (Utils.cmp(test, "not(euint64)")) {
-            return FHE.decrypt(FHE.not(FHE.asEuint64(a)));
+            return FHE.decrypt(FHE.not(FHE.asEuint64(a, securityZone)));
         } else if (Utils.cmp(test, "not(euint128)")) {
-            return FHE.decrypt(FHE.not(FHE.asEuint128(a)));
+            return FHE.decrypt(FHE.not(FHE.asEuint128(a, securityZone)));
         } else if (Utils.cmp(test, "not(ebool)")) {
             bool aBool = true;
             if (a == 0) {
                 aBool = false;
             }
 
-            if (FHE.decrypt(FHE.not(FHE.asEbool(aBool)))) {
+            if (FHE.decrypt(FHE.not(FHE.asEbool(aBool, securityZone)))) {
                 return 1;
             }
 

--- a/solidity/tests/contracts/asEaddress.sol
+++ b/solidity/tests/contracts/asEaddress.sol
@@ -24,6 +24,10 @@ contract AsEaddressTest {
         return FHE.decrypt(FHE.asEaddress(val));
     }
 
+    function castFromPlaintextAddressToEaddress(address val) public pure returns (address) {
+        return FHE.decrypt(FHE.asEaddress(val));
+    }
+
     function castFromPreEncryptedToEaddress(inEaddress calldata val) public pure returns (address) {
         return FHE.decrypt(FHE.asEaddress(val));
     }

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -1489,7 +1489,6 @@ describe("Test Not", () => {
         it.only(`Test ${test.function} !${input} - security zone ${securityZone}`, async () => {
           let val = BigInt(+input);
           let expectedResult = BigInt(+(!input));
-          console.log("input", val, "expectedResult", expectedResult);
           if (test.bits !== 1) {
             val = BigInt.asUintN(test.bits, BigInt(+input));
             expectedResult = (1n << BigInt(test.bits)) - BigInt(1 + (+input));
@@ -1497,7 +1496,6 @@ describe("Test Not", () => {
 
           const decryptedResult = await contract.not(test.function, val, securityZone);
 
-          console.log("output", decryptedResult, "expectedResult", expectedResult);
           expect(decryptedResult).toBe(expectedResult);
         });
       }

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -2273,19 +2273,19 @@ describe("Test AsEuint256", () => {
   });
 
   it(`From pre encrypted`, async () => {
-    const encInput = await fheContract.instance.encrypt_uint256(value); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_uint256(value);
     let decryptedResult = await contract.castFromPreEncryptedToEuint256(encInput);
     expect(decryptedResult).toBe(value);
   });
 
   it(`From pre encrypted - Security Zone 1`, async () => {
-    const encInput = await fheContract.instance.encrypt_uint256(value, 1); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_uint256(value, 1);
     let decryptedResult = await contract.castFromPreEncryptedToEuint256(encInput);
     expect(decryptedResult).toBe(value);
   });
 });
 
-describe("Test AsEaddress", () => {
+describe.only("Test AsEaddress", () => {
   let contract;
   let fheContract;
 
@@ -2302,7 +2302,6 @@ describe("Test AsEaddress", () => {
 
   const value = BigInt(455113547441765951074000967332144802967768096399n); //0x4fB7FF4e004FcADbff708d8d873592B2044d5E8f
   const funcTypes = ["regular", "bound"];
-
 
   for (const funcType of funcTypes) {
     it(`From euint256 - ${funcType}`, async () => {
@@ -2333,15 +2332,21 @@ describe("Test AsEaddress", () => {
     expect(decimal).toBe(bigNumber);
   });
 
+  it(`From plaintext address`, async () => {
+    let decryptedResult = await contract.castFromPlaintextAddressToEaddress("0x4fB7FF4e004FcADbff708d8d873592B2044d5E8f");
+    let decimal = BigInt(decryptedResult);
+    expect(decimal).toBe(value);
+  });
+
   it(`From pre encrypted`, async () => {
-    const encInput = await fheContract.instance.encrypt_address(value); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_address(value);
     let decryptedResult = await contract.castFromPreEncryptedToEaddress(encInput);
     let decimal = BigInt(decryptedResult);
     expect(decimal).toBe(value);
   });
 
   it(`From pre encrypted - Security Zone 1`, async () => {
-    const encInput = await fheContract.instance.encrypt_address(value, 1); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_address(value, 1);
     let decryptedResult = await contract.castFromPreEncryptedToEaddress(encInput);
     let decimal = BigInt(decryptedResult);
     expect(decimal).toBe(value);

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -1451,7 +1451,7 @@ describe("Test Not", () => {
   let contract;
 
   // We don't really need it as test but it is a test since it is async
-  it.only(`Test Contract Deployment`, async () => {
+  it(`Test Contract Deployment`, async () => {
     contract = (await deployContract("NotTest")) as NotTestType;
     expect(contract).toBeTruthy();
   });
@@ -1486,7 +1486,7 @@ describe("Test Not", () => {
   for (const test of testCases) {
     for (const securityZone of [0, 1]) {
       for (const input of [true, false]) {
-        it.only(`Test ${test.function} !${input} - security zone ${securityZone}`, async () => {
+        it(`Test ${test.function} !${input} - security zone ${securityZone}`, async () => {
           let val = BigInt(+input);
           let expectedResult = BigInt(+(!input));
           if (test.bits !== 1) {

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -1451,79 +1451,56 @@ describe("Test Not", () => {
   let contract;
 
   // We don't really need it as test but it is a test since it is async
-  it(`Test Contract Deployment`, async () => {
+  it.only(`Test Contract Deployment`, async () => {
     contract = (await deployContract("NotTest")) as NotTestType;
     expect(contract).toBeTruthy();
   });
 
   const testCases = [
     {
+      function: "not(ebool)",
+      bits: 1,
+    },
+    {
       function: "not(euint8)",
-      cases: [
-        {
-          bits: 8,
-          name: "",
-        },
-      ],
+      bits: 8,
     },
     {
       function: "not(euint16)",
-      cases: [
-        {
-          bits: 16,
-          name: "",
-        },
-      ],
+      bits: 16,
     },
     {
       function: "not(euint32)",
-      cases: [
-        {
-          bits: 32,
-          name: "",
-        },
-      ],
-    },
-    {
-      function: "not(ebool)",
-      cases: [
-        { bits: 1, name: " !true" },
-        { bits: 1, name: " !false" },
-      ],
+      bits: 32,
     },
     {
       function: "not(euint64)",
-      cases: [
-        {
-          bits: 64,
-          name: "",
-        },
-      ],
+      bits: 64,
     },
     {
       function: "not(euint128)",
-      cases: [
-        {
-          bits: 128,
-          name: "",
-        },
-      ],
+      bits: 128,
     },
   ];
 
   for (const test of testCases) {
-    for (const testCase of test.cases) {
-      it(`Test ${test.function}${testCase.name}`, async () => {
-        let val = BigInt(1);
-        let expectedResult = BigInt(0);
-        if (testCase.bits !== 1) {
-          val = BigInt.asUintN(testCase.bits, BigInt(1));
-          expectedResult = (val << BigInt(testCase.bits)) - BigInt(2);
-        }
+    for (const securityZone of [0, 1]) {
+      for (const input of [true, false]) {
+        it.only(`Test ${test.function} !${input} - security zone ${securityZone}`, async () => {
+          let val = BigInt(+input);
+          let expectedResult = BigInt(+(!input));
+          console.log("input", val, "expectedResult", expectedResult);
+          if (test.bits !== 1) {
+            val = BigInt.asUintN(test.bits, BigInt(+input));
+            expectedResult = (1n << BigInt(test.bits)) - BigInt(1 + (+input));
+          }
 
-        const decryptedResult = await contract.not(test.function, BigInt(val));
-        expect(decryptedResult).toBe(expectedResult);
-      });
+          const decryptedResult = await contract.not(test.function, val, securityZone);
+
+          console.log("output", decryptedResult, "expectedResult", expectedResult);
+          expect(decryptedResult).toBe(expectedResult);
+        });
+      }
     }
   }
 });


### PR DESCRIPTION
I noticed there's no `set_server_key` on the engine on unary operators, so I wanted to test the unary precompiles to see if they fail on different security zones, so I expanded the tests to test once for security zone 0 and once for 1.
The tests did not seem to care if the server_key is set or not, which is pretty weird... same as with cast. **But** they did expose another bug we have: namely, the casting from euint to ebool will fail for non-default security zones, because internally it uses the `ne` fhe comparison with a constant (0 encrypted) that belongs to security zone 0, meaning it will fail because ne is done with two operands that are different security zones. _This is why the CI will not pass here._
We could fix it in the following ways:
1. leaving the asEbool cast as is and documenting the caveats with working with non-default security zones. namely, the developer will have to manually trivially encrypt the constant 0 for the security zone in question, and then do `ne`.
2. supporting the native cast of the `TfheBool` type in the engine. (currently there's a comment that says it apparently isn't supported and that we have to dig deeper to understand completely?)
3. implementing the `ne` hack on the precompile level, which is aware of security zones. Specifically, the Cast precompile should check if the toType is bool, and then if it is, trivially encrypt the zero for that security zone, and passing it to Ne as opposed to cast.

added a monday task for this: https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1563307282