### PR TITLE
Fix cast eaddress support on lib

### DIFF
--- a/solgen/common.ts
+++ b/solgen/common.ts
@@ -25,6 +25,9 @@ const patternAllowedOperationsEuint256 =   ["ne|eq|sealoutput|select|seal|decryp
 const patternAllowedOperationsEaddress =   ["ne|^eq$|sealoutput|select|seal|decrypt"];
 /*------------------------------------------------------------*/
 
+// Although casts from eaddress to types with < 256 bits are possible, we don't want to test them.
+export const AllowedTypesOnCastToEaddress = ["euint256", "uint256", "inEaddress", "bytes memory", "address"]
+
 export const AllowedOperations = [
   patternAllowedOperationsEbool,
   patternAllowedOperationsEuint8,

--- a/solgen/solgen.ts
+++ b/solgen/solgen.ts
@@ -428,7 +428,7 @@ const main = async () => {
       outputFile += AsTypeFunction(fromType, toType);
     }
   }
-  // (Hardcoded) For a better UX we need to be able to cast address to eaddress, the following line does so:
+  // For a better UX, allow casting from address to eaddress:
   outputFile += AsTypeFunction('address', 'eaddress')
   
   for (let type of EInputType) {

--- a/solgen/templates/benchContracts.ts
+++ b/solgen/templates/benchContracts.ts
@@ -6,7 +6,7 @@ import {
   toInType,
   toInTypeParam,
   toVarSuffix,
-  toAsType,
+  toAsType, AllowedTypesOnCastToEaddress,
 } from "../common";
 
 const IsOperationAllowed = (
@@ -175,9 +175,8 @@ export function AsTypeBenchmarkContract(type: string) {
   let loads = "";
   let casts = "";
 
-  // Although casts from eaddress to types with < 256 bits are possible, we don't want to bench them.
-  let eaddressAllowedTypes = ["euint256"];
-  let fromTypeCollection = type === "eaddress" ? eaddressAllowedTypes : EInputType;
+  const eaddressTypes = AllowedTypesOnCastToEaddress.filter(t => t.startsWith("e")); // filter out built-in-types which we deal with explicitly
+  let fromTypeCollection = type === "eaddress" ? eaddressTypes : EInputType;
 
   for (let fromType of fromTypeCollection) {
     if (fromType === type) {

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -11,6 +11,7 @@ import {
   LOCAL_SEAL_FUNCTION_NAME,
   LOCAL_DECRYPT_FUNCTION_NAME,
   AllowedOperations,
+  AllowedTypesOnCastToEaddress,
   toPlaintextType,
   capitalize,
   shortenType,
@@ -251,6 +252,11 @@ const castToEbool = (name: string, fromType: string): string => {
 };
 
 export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone: boolean = false) => {
+  if (toType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(fromType) ) {
+    console.log("skipping: ", fromType, "to", toType);
+    return ""; // skip unsupported cast
+  }
+
   let castString = castFromEncrypted(fromType, toType, "value");
   let overrideFuncs = '';
 
@@ -665,6 +671,11 @@ export const OperatorBinding = (
 };
 
 export const CastBinding = (thisType: string, targetType: string) => {
+  if (targetType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(thisType) ) {
+    console.log("binding - skipping: ", thisType, "to", targetType);
+    return ""; // skip unsupported cast
+  }
+
   return `
     function to${shortenType(
       targetType

--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -253,7 +253,6 @@ const castToEbool = (name: string, fromType: string): string => {
 
 export const AsTypeFunction = (fromType: string, toType: string, addSecurityZone: boolean = false) => {
   if (toType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(fromType) ) {
-    console.log("skipping: ", fromType, "to", toType);
     return ""; // skip unsupported cast
   }
 
@@ -672,7 +671,6 @@ export const OperatorBinding = (
 
 export const CastBinding = (thisType: string, targetType: string) => {
   if (targetType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(thisType) ) {
-    console.log("binding - skipping: ", thisType, "to", targetType);
     return ""; // skip unsupported cast
   }
 

--- a/solgen/templates/testContracts.ts
+++ b/solgen/templates/testContracts.ts
@@ -4,8 +4,11 @@ import {
   SEAL_RETURN_TYPE,
   LOCAL_SEAL_FUNCTION_NAME,
   AllowedOperations,
+  AllowedTypesOnCastToEaddress,
   capitalize,
-  shortenType, toInType, toInTypeParam,
+  shortenType,
+  toInType,
+  toInTypeParam,
 } from "../common";
 
 function TypeCastTestingFunction(
@@ -54,13 +57,11 @@ export function AsTypeTestingContract(type: string) {
     type
   )}TestType extends BaseContract {\n`;
 
-  // Although casts from eaddress to types with < 256 bits are possible, we don't want to test them.
-  let eaddressAllowedTypes = ["euint256", "uint256"];
-  let fromTypeCollection = type === "eaddress" ? eaddressAllowedTypes : EInputType.concat("uint256");
+  let fromTypeCollection = type === "eaddress" ? AllowedTypesOnCastToEaddress : EInputType.concat("uint256");
   fromTypeCollection = fromTypeCollection.concat(toInTypeParam(type));
 
   for (const fromType of fromTypeCollection) {
-    if (type === fromType || (fromType === "eaddress" && !eaddressAllowedTypes.includes(type))) {
+    if (type === fromType || (fromType === "eaddress" && !AllowedTypesOnCastToEaddress.includes(type))) {
       continue;
     }
 

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -2533,10 +2533,6 @@ library FHE {
     function asEuint256(ebool value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EBOOL_TFHE, ebool.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a ebool to an eaddress
-    function asEaddress(ebool value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EBOOL_TFHE, ebool.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint8 to an ebool
     function asEbool(euint8 value) internal pure returns (ebool) {
@@ -2567,10 +2563,6 @@ library FHE {
     /// @notice Converts a euint8 to an euint256
     function asEuint256(euint8 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT8_TFHE, euint8.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint8 to an eaddress
-    function asEaddress(euint8 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT8_TFHE, euint8.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint16 to an ebool
@@ -2603,10 +2595,6 @@ library FHE {
     function asEuint256(euint16 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT16_TFHE, euint16.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a euint16 to an eaddress
-    function asEaddress(euint16 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT16_TFHE, euint16.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint32 to an ebool
     function asEbool(euint32 value) internal pure returns (ebool) {
@@ -2637,10 +2625,6 @@ library FHE {
     /// @notice Converts a euint32 to an euint256
     function asEuint256(euint32 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT32_TFHE, euint32.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint32 to an eaddress
-    function asEaddress(euint32 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT32_TFHE, euint32.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint64 to an ebool
@@ -2673,10 +2657,6 @@ library FHE {
     function asEuint256(euint64 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT64_TFHE, euint64.unwrap(value), Common.EUINT256_TFHE));
     }
-    /// @notice Converts a euint64 to an eaddress
-    function asEaddress(euint64 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT64_TFHE, euint64.unwrap(value), Common.EADDRESS_TFHE));
-    }
     
     /// @notice Converts a euint128 to an ebool
     function asEbool(euint128 value) internal pure returns (ebool) {
@@ -2707,10 +2687,6 @@ library FHE {
     /// @notice Converts a euint128 to an euint256
     function asEuint256(euint128 value) internal pure returns (euint256) {
         return euint256.wrap(Impl.cast(Common.EUINT128_TFHE, euint128.unwrap(value), Common.EUINT256_TFHE));
-    }
-    /// @notice Converts a euint128 to an eaddress
-    function asEaddress(euint128 value) internal pure returns (eaddress) {
-        return eaddress.wrap(Impl.cast(Common.EUINT128_TFHE, euint128.unwrap(value), Common.EADDRESS_TFHE));
     }
     
     /// @notice Converts a euint256 to an ebool
@@ -3236,9 +3212,6 @@ library BindingsEbool {
     function toU256(ebool value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(ebool value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(ebool value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3410,9 +3383,6 @@ library BindingsEuint8 {
     }
     function toU256(euint8 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
-    }
-    function toEaddress(euint8 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
     }
     function seal(euint8 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
@@ -3586,9 +3556,6 @@ library BindingsEuint16 {
     function toU256(euint16 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint16 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint16 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3761,9 +3728,6 @@ library BindingsEuint32 {
     function toU256(euint32 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint32 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint32 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -3920,9 +3884,6 @@ library BindingsEuint64 {
     function toU256(euint64 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
     }
-    function toEaddress(euint64 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
-    }
     function seal(euint64 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);
     }
@@ -4070,9 +4031,6 @@ library BindingsEuint128 {
     }
     function toU256(euint128 value) internal pure returns (euint256) {
         return FHE.asEuint256(value);
-    }
-    function toEaddress(euint128 value) internal pure returns (eaddress) {
-        return FHE.asEaddress(value);
     }
     function seal(euint128 value, bytes32 publicKey) internal pure returns (string memory) {
         return FHE.sealoutput(value, publicKey);

--- a/solidity/tests/abis.ts
+++ b/solidity/tests/abis.ts
@@ -145,9 +145,7 @@ export interface AsEuint256TestType extends BaseContract {
 export interface AsEaddressTestType extends BaseContract {
     castFromEuint256ToEaddress: (val: bigint, test: string) => Promise<bigint>;
     castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
-    castFromPreEncryptedToEaddress: (val: EncryptedNumber) => Promise<bigint>;
-    castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
-    castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
+    castFromPlaintextAddressToEaddress: (val: bigint) => Promise<bigint>;
     castFromPreEncryptedToEaddress: (val: EncryptedNumber) => Promise<bigint>;
 }
 

--- a/solidity/tests/abis.ts
+++ b/solidity/tests/abis.ts
@@ -146,5 +146,8 @@ export interface AsEaddressTestType extends BaseContract {
     castFromEuint256ToEaddress: (val: bigint, test: string) => Promise<bigint>;
     castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
     castFromPreEncryptedToEaddress: (val: EncryptedNumber) => Promise<bigint>;
+    castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
+    castFromPlaintextToEaddress: (val: bigint) => Promise<bigint>;
+    castFromPreEncryptedToEaddress: (val: EncryptedNumber) => Promise<bigint>;
 }
 

--- a/solidity/tests/contracts/asEaddress.sol
+++ b/solidity/tests/contracts/asEaddress.sol
@@ -24,6 +24,10 @@ contract AsEaddressTest {
         return FHE.decrypt(FHE.asEaddress(val));
     }
 
+    function castFromPlaintextAddressToEaddress(address val) public pure returns (address) {
+        return FHE.decrypt(FHE.asEaddress(val));
+    }
+
     function castFromPreEncryptedToEaddress(inEaddress calldata val) public pure returns (address) {
         return FHE.decrypt(FHE.asEaddress(val));
     }

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -2273,13 +2273,13 @@ describe("Test AsEuint256", () => {
   });
 
   it(`From pre encrypted`, async () => {
-    const encInput = await fheContract.instance.encrypt_uint256(value); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_uint256(value);
     let decryptedResult = await contract.castFromPreEncryptedToEuint256(encInput);
     expect(decryptedResult).toBe(value);
   });
 
   it(`From pre encrypted - Security Zone 1`, async () => {
-    const encInput = await fheContract.instance.encrypt_uint256(value, 1); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_uint256(value, 1);
     let decryptedResult = await contract.castFromPreEncryptedToEuint256(encInput);
     expect(decryptedResult).toBe(value);
   });
@@ -2302,7 +2302,6 @@ describe("Test AsEaddress", () => {
 
   const value = BigInt(455113547441765951074000967332144802967768096399n); //0x4fB7FF4e004FcADbff708d8d873592B2044d5E8f
   const funcTypes = ["regular", "bound"];
-
 
   for (const funcType of funcTypes) {
     it(`From euint256 - ${funcType}`, async () => {
@@ -2334,14 +2333,14 @@ describe("Test AsEaddress", () => {
   });
 
   it(`From pre encrypted`, async () => {
-    const encInput = await fheContract.instance.encrypt_address(value); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_address(value);
     let decryptedResult = await contract.castFromPreEncryptedToEaddress(encInput);
     let decimal = BigInt(decryptedResult);
     expect(decimal).toBe(value);
   });
 
   it(`From pre encrypted - Security Zone 1`, async () => {
-    const encInput = await fheContract.instance.encrypt_address(value, 1); // Adjust encryption method if necessary
+    const encInput = await fheContract.instance.encrypt_address(value, 1);
     let decryptedResult = await contract.castFromPreEncryptedToEaddress(encInput);
     let decimal = BigInt(decryptedResult);
     expect(decimal).toBe(value);

--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -2285,7 +2285,7 @@ describe("Test AsEuint256", () => {
   });
 });
 
-describe("Test AsEaddress", () => {
+describe.only("Test AsEaddress", () => {
   let contract;
   let fheContract;
 
@@ -2330,6 +2330,12 @@ describe("Test AsEaddress", () => {
     let decryptedResult = await contract.castFromPlaintextToEaddress(bigNumber);
     let decimal = BigInt(decryptedResult);
     expect(decimal).toBe(bigNumber);
+  });
+
+  it(`From plaintext address`, async () => {
+    let decryptedResult = await contract.castFromPlaintextAddressToEaddress("0x4fB7FF4e004FcADbff708d8d873592B2044d5E8f");
+    let decimal = BigInt(decryptedResult);
+    expect(decimal).toBe(value);
   });
 
   it(`From pre encrypted`, async () => {


### PR DESCRIPTION
_CI tests fail consciously because of the description [here](https://github.com/FhenixProtocol/fheos/pull/118)_ 

the library exported `asEaddress` functions for inputs of type euint{8,16,32,64,128} which are not supported by the precompiles,
so I removed them from the library so that contract developers will get a compilation error instead of a provider error once the contract is up. Also removed the `.toEaddress()` bindings from the euints
Side effect: there is one more test for `asEaddress(address)`

monday: https://fhenix.monday.com/boards/1216577959/views/4451803/pulses/1528339247