### PR TITLE
restore tests

### DIFF
--- a/solidity/tests/precompiles.test.ts
+++ b/solidity/tests/precompiles.test.ts
@@ -2285,7 +2285,7 @@ describe("Test AsEuint256", () => {
   });
 });
 
-describe.only("Test AsEaddress", () => {
+describe("Test AsEaddress", () => {
   let contract;
   let fheContract;
 


### PR DESCRIPTION
I forgot to remove an `only` in the tests, this restores it and causes all tests to run as they should.
Note that it should not pass because there's a bug with the asEbool(euint), described elsewhere. The PRs that were merged to master passed the CI artificially because of this remaining `only`.