### PR TITLE
Parallel decryptions: minor changes to fheos structs

### DIFF
--- a/precompiles/types/decryption_results.go
+++ b/precompiles/types/decryption_results.go
@@ -61,38 +61,16 @@ func (dr *DecryptionResults) SetValue(key PendingDecryption, value any) error {
 	return nil
 }
 
-func (dr *DecryptionResults) Get(key PendingDecryption) (any, bool, time.Time, error) {
+func (dr *DecryptionResults) Get(key PendingDecryption) (DecryptionRecord, bool) { //(any, bool, time.Time, error) {
 	dr.mu.RLock()
 	defer dr.mu.RUnlock()
 
 	record, exists := dr.data[key]
 	if !exists {
-		return nil, false, time.Time{}, nil
+		return DecryptionRecord{}, false
 	}
 
-	if record.Value == nil {
-		return nil, true, record.Timestamp, nil // Exists but no value
-	}
-
-	switch key.Type {
-	case SealOutput:
-		if bytes, ok := record.Value.([]byte); ok {
-			return bytes, true, record.Timestamp, nil
-		}
-		return nil, true, record.Timestamp, fmt.Errorf("value is not []byte as expected for SealOutput")
-	case Require:
-		if boolValue, ok := record.Value.(bool); ok {
-			return boolValue, true, record.Timestamp, nil
-		}
-		return nil, true, record.Timestamp, fmt.Errorf("value is not bool as expected for Require")
-	case Decrypt:
-		if bigInt, ok := record.Value.(*big.Int); ok {
-			return bigInt, true, record.Timestamp, nil
-		}
-		return nil, true, record.Timestamp, fmt.Errorf("value is not *big.Int as expected for Decrypt")
-	default:
-		return nil, true, record.Timestamp, fmt.Errorf("unknown PrecompileName")
-	}
+	return record, true
 }
 
 func (dr *DecryptionResults) Remove(key PendingDecryption) {

--- a/precompiles/types/decryption_results.go
+++ b/precompiles/types/decryption_results.go
@@ -69,7 +69,7 @@ func (dr *DecryptionResults) SetValue(key PendingDecryption, value any) error {
 	return nil
 }
 
-func (dr *DecryptionResults) Get(key PendingDecryption) (DecryptionRecord, bool) { //(any, bool, time.Time, error) {
+func (dr *DecryptionResults) Get(key PendingDecryption) (DecryptionRecord, bool) {
 	dr.mu.RLock()
 	defer dr.mu.RUnlock()
 

--- a/precompiles/types/decryption_results.go
+++ b/precompiles/types/decryption_results.go
@@ -5,10 +5,12 @@ import (
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/fhenixprotocol/warp-drive/fhe-driver"
 )
 
 type PendingDecryption struct {
-	Hash Hash
+	Hash fhe.Hash
 	Type PrecompileName
 }
 
@@ -28,6 +30,12 @@ func NewDecryptionResultsMap() *DecryptionResults {
 	}
 }
 
+// CreateEmptyRecord creates a new empty record for the given PendingDecryption key
+// if it doesn't already exist in the DecryptionResults map.
+// This function is intended to be used once a parallel decryption is initiated,
+// before we have a result. An empty record indicates that this decryption is pending.
+// The new record will have a nil Value and the current timestamp.
+// This method is thread-safe.
 func (dr *DecryptionResults) CreateEmptyRecord(key PendingDecryption) {
 	dr.mu.Lock()
 	defer dr.mu.Unlock()


### PR DESCRIPTION
* In the function `Get()` that returns a decryption request record, offload the type assertion to the caller. The caller will have to do type assertion anyway (since the value return type is `any`), and that simplifies the `Get()` function.
* Changed the `Hash` type to be compatible with `BytesToHash()`
* Fixed tests accordingly