### PR TITLE
Parallel decryptions: use tx hash instead of block hash in auto-seeding

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"encoding/hex"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
@@ -153,6 +154,8 @@ func (h FheOSHooksImpl) EvmCallEnd(evmSuccess bool) {
 			log.Info("Deleted ciphertext", "hash", hex.EncodeToString(hash[:]))
 		}
 	}
+
+	fheos.State.RandomCounter = 0
 }
 
 func shouldIgnoreContract(caller common.Address, addr common.Address) bool {

--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/fhenixprotocol/fheos/precompiles/types"
 	storage2 "github.com/fhenixprotocol/fheos/storage"
 	"github.com/fhenixprotocol/warp-drive/fhe-driver"
@@ -1556,29 +1555,16 @@ func Random(utype byte, seed uint64, securityZone int32, tp *TxParams) ([]byte, 
 	if seed != 0 {
 		finalSeed = seed
 	} else {
-		// Seed generation
-		// The current block hash is not yet calculated, se we use the previous block hash
-		var prevBlockHash = common.Hash{}
-
-		if tp.BlockNumber != nil {
-			prevBlockNumber := tp.BlockNumber.Uint64() - 1
-			prevBlockHash = tp.GetBlockHash(prevBlockNumber)
-		} else {
-			logger.Warn("missing BlockNumber inside precompile")
-		}
-
 		var randomCounter uint64
 		if tp.Commit {
-			// We're incrementing nonce regardless of whether the transaction is successful or not,
-			// so that even after a revert, the random is different.
-			// Secondly, we're incrementing before the request for the random number, so that queries
+			// We're incrementing before the request for the random number, so that queries
 			// that came before this Tx would have received a different seed.
-			randomCounter = State.IncRandomCounter(prevBlockHash)
+			randomCounter = State.IncRandomCounter()
 		} else {
-			randomCounter = State.GetRandomCounter(prevBlockHash)
+			randomCounter = State.GetRandomCounter()
 		}
 
-		finalSeed = GenerateSeedFromEntropy(tp.ContractAddress, prevBlockHash, randomCounter)
+		finalSeed = GenerateSeedFromEntropy(tp.ContractAddress, tp.TxContext.Hash, randomCounter)
 	}
 
 	result, err := fhe.FheRandom(securityZone, uintType, finalSeed)

--- a/precompiles/state.go
+++ b/precompiles/state.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/fhenixprotocol/fheos/precompiles/types"
 	storage2 "github.com/fhenixprotocol/fheos/storage"
@@ -74,28 +73,12 @@ func (fs *FheosState) SetCiphertext(ct *types.CipherTextRepresentation) error {
 	return result
 }
 
-func (fs *FheosState) GetRandomCounter(latestHash common.Hash) uint64 {
-	if fs.LastSavedHash == nil || *fs.LastSavedHash != latestHash {
-		return 0
-	} else if *fs.LastSavedHash == latestHash {
-		return fs.RandomCounter
-	}
-
-	logger.Warn("unexpected error in GetRandomCounter")
-	return 0
+func (fs *FheosState) GetRandomCounter() uint64 {
+	return fs.RandomCounter
 }
 
-func (fs *FheosState) IncRandomCounter(latestHash common.Hash) uint64 {
-	if fs.LastSavedHash == nil || *fs.LastSavedHash != latestHash {
-		fs.LastSavedHash = &latestHash
-		fs.RandomCounter = 1
-		log.Debug("new block, counter reset on increment", "counter", fs.RandomCounter)
-	} else if *fs.LastSavedHash == latestHash {
-		fs.RandomCounter += 1
-		log.Debug("counter incremented", "counter", fs.RandomCounter)
-	} else {
-		logger.Warn("unexpected error in IncRandomCounter")
-	}
+func (fs *FheosState) IncRandomCounter() uint64 {
+	fs.RandomCounter += 1
 
 	return fs.RandomCounter
 }

--- a/precompiles/state.go
+++ b/precompiles/state.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/fhenixprotocol/fheos/precompiles/types"
 	storage2 "github.com/fhenixprotocol/fheos/storage"
@@ -17,7 +16,6 @@ type FheosState struct {
 	FheosVersion   uint64
 	Storage        storage2.FheosStorage
 	RandomCounter  uint64
-	LastSavedHash  *common.Hash
 	DecryptResults *types.DecryptionResults
 	//MaxUintValue *big.Int // This should contain the max value of the supported uint type
 }
@@ -79,7 +77,6 @@ func (fs *FheosState) GetRandomCounter() uint64 {
 
 func (fs *FheosState) IncRandomCounter() uint64 {
 	fs.RandomCounter += 1
-
 	return fs.RandomCounter
 }
 
@@ -88,7 +85,6 @@ func createFheosState(storage storage2.FheosStorage, version uint64) {
 		version,
 		storage,
 		0,
-		nil,
 		types.NewDecryptionResultsMap(),
 	}
 }

--- a/precompiles/utils.go
+++ b/precompiles/utils.go
@@ -129,11 +129,11 @@ func evaluateRequire(ct *fhe.FheEncrypted) bool {
 	return fhe.Require(ct)
 }
 
-func GenerateSeedFromEntropy(contractAddress common.Address, prevBlockHash common.Hash, randomCounter uint64) uint64 {
-	data := make([]byte, 0, len(contractAddress)+len(prevBlockHash)+8) // 8 bytes for uint64
+func GenerateSeedFromEntropy(contractAddress common.Address, txHash common.Hash, randomCounter uint64) uint64 {
+	data := make([]byte, 0, len(contractAddress)+len(txHash)+8) // 8 bytes for uint64
 
 	data = append(data, contractAddress[:]...)
-	data = append(data, prevBlockHash[:]...)
+	data = append(data, txHash[:]...)
 
 	uint64Bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(uint64Bytes, randomCounter)

--- a/precompiles/utils.go
+++ b/precompiles/utils.go
@@ -25,6 +25,7 @@ type TxParams struct {
 	GetBlockHash    vm.GetHashFunc
 	BlockNumber     *big.Int
 	ParallelTxHooks types.ParallelTxProcessingHook
+	vm.TxContext
 }
 
 type GasBurner interface {
@@ -49,6 +50,8 @@ func TxParamsFromEVM(evm *vm.EVM, callerContract common.Address) TxParams {
 	} else {
 		tp.ParallelTxHooks = nil
 	}
+
+	tp.TxContext = evm.TxContext
 
 	return tp
 }

--- a/precompiles/utils.go
+++ b/precompiles/utils.go
@@ -129,11 +129,11 @@ func evaluateRequire(ct *fhe.FheEncrypted) bool {
 	return fhe.Require(ct)
 }
 
-func GenerateSeedFromEntropy(contractAddress common.Address, txHash common.Hash, randomCounter uint64) uint64 {
-	data := make([]byte, 0, len(contractAddress)+len(txHash)+8) // 8 bytes for uint64
+func GenerateSeedFromEntropy(contractAddress common.Address, hash common.Hash, randomCounter uint64) uint64 {
+	data := make([]byte, 0, len(contractAddress)+len(hash)+8) // 8 bytes for uint64
 
 	data = append(data, contractAddress[:]...)
-	data = append(data, txHash[:]...)
+	data = append(data, hash[:]...)
 
 	uint64Bytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(uint64Bytes, randomCounter)


### PR DESCRIPTION
By doing this, you get deterministic random numbers for a given TX.
This should be ok from a security standpoint, as long as you make sure that the sender is a EOA and can't revert the TX based on it's outcome.