### PR TITLE
Fheos db path config

### DIFF
--- a/chains/arbitrum/config.go
+++ b/chains/arbitrum/config.go
@@ -12,6 +12,7 @@ func FhenixConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".fallback-fhe-engine-address", fhe.ConfigDefault.FallbackFheEngineAddress, "FHE engine fallback address")
 	f.String(prefix+".home-dir", fhe.ConfigDefault.HomeDir, "FHE home directory")
 	f.Int(prefix+".log-level", fhe.ConfigDefault.LogLevel, "Minimum log level to display (0-5)")
+	f.String(prefix+".fheos-db-path", fhe.ConfigDefault.FheosDbPath, "Path for FheOs database")
 }
 
 type FhenixConfig = fhe.Config

--- a/chains/arbitrum/config.go
+++ b/chains/arbitrum/config.go
@@ -12,7 +12,6 @@ func FhenixConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".fallback-fhe-engine-address", fhe.ConfigDefault.FallbackFheEngineAddress, "FHE engine fallback address")
 	f.String(prefix+".home-dir", fhe.ConfigDefault.HomeDir, "FHE home directory")
 	f.Int(prefix+".log-level", fhe.ConfigDefault.LogLevel, "Minimum log level to display (0-5)")
-	f.String(prefix+".fheos-db-path", fhe.ConfigDefault.FheosDbPath, "Path for FheOs database")
 }
 
 type FhenixConfig = fhe.Config

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/fhenixprotocol/fheos/conf"
 	"github.com/fhenixprotocol/fheos/precompiles"
 	fhedriver "github.com/fhenixprotocol/warp-drive/fhe-driver"
 	"github.com/spf13/cobra"
@@ -64,7 +65,12 @@ func generateKeys(securityZones int32) error {
 }
 
 func initDbOnly() error {
-	err := precompiles.InitFheos(&fhedriver.ConfigDefault)
+	configFheos := conf.ConfigDefault
+	if path := os.Getenv("FHEOS_DB_PATH"); path != "" {
+		configFheos.FheosDbPath = path
+	}
+
+	err := precompiles.InitFheos(&fhedriver.ConfigDefault, &configFheos)
 	if err != nil {
 		return err
 	}
@@ -73,13 +79,7 @@ func initDbOnly() error {
 }
 
 func initFheos() (*precompiles.TxParams, error) {
-	config := fhedriver.ConfigDefault
-
-	if path := os.Getenv("FHEOS_DB_PATH"); path != "" {
-		config.FheosDbPath = path
-	}
-
-	err := precompiles.InitFheConfig(&config)
+	err := initDbOnly()
 	if err != nil {
 		return nil, err
 	}
@@ -89,16 +89,6 @@ func initFheos() (*precompiles.TxParams, error) {
 		return nil, err
 	}
 	err = generateKeys(int32(securityZones))
-	if err != nil {
-		return nil, err
-	}
-
-	err = precompiles.InitializeFheosState()
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.Setenv("FHEOS_DB_PATH", "")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,14 +73,13 @@ func initDbOnly() error {
 }
 
 func initFheos() (*precompiles.TxParams, error) {
-	if os.Getenv("FHEOS_DB_PATH") == "" {
-		err := os.Setenv("FHEOS_DB_PATH", "./fheosdb")
-		if err != nil {
-			return nil, err
-		}
+	config := fhedriver.ConfigDefault
+
+	if path := os.Getenv("FHEOS_DB_PATH"); path != "" {
+		config.FheosDbPath = path
 	}
 
-	err := precompiles.InitFheConfig(&fhedriver.ConfigDefault)
+	err := precompiles.InitFheConfig(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -207,9 +207,30 @@ func setupOperationCommand(use, short string, op operationFunc) *cobra.Command {
 func main() {
 	var rootCmd = &cobra.Command{Use: "fheos"}
 
+	var initKeysCmd = &cobra.Command{
+		Use:   "init-keys",
+		Short: "Initialize fheos keys (create them and send them to the engine)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			confWd, confFheos, err := initConfigs()
+			if err != nil {
+				return err
+			}
+
+			err = precompiles.InitFheConfig(confWd)
+			if err != nil {
+				return err
+			}
+
+			conf.SetConfig(*confFheos)
+
+			err = initKeys()
+			return err
+		},
+	}
+
 	var initState = &cobra.Command{
 		Use:   "init-state",
-		Short: "Initialize fheos state",
+		Short: "Initialize fheos state (keys + db)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			confWd, confFheos, err := initConfigs()
 			if err != nil {
@@ -225,7 +246,7 @@ func main() {
 		},
 	}
 
-	var initDbCommand = &cobra.Command{
+	var initDbCmd = &cobra.Command{
 		Use:   "init-db",
 		Short: "Initialize fheos db only (no keys)",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -259,7 +280,7 @@ func main() {
 	var rol = setupOperationCommand("rol", "ror two numbers", precompiles.Rol)
 	var ror = setupOperationCommand("ror", "rol two numbers", precompiles.Rol)
 
-	rootCmd.AddCommand(initDbCommand, initState, add, sub, lte, sub, mul, lt, div, gt, gte, rem, and, or, xor, eq, ne, min, max, shl, shr, rol, ror)
+	rootCmd.AddCommand(initDbCmd, initState, initKeysCmd, add, sub, lte, sub, mul, lt, div, gt, gte, rem, and, or, xor, eq, ne, min, max, shl, shr, rol, ror)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,17 +15,11 @@ import (
 )
 
 func removeDb() error {
-	env := os.Getenv("FHEOS_DB_PATH")
-	if env == "" {
-		return nil
-	}
-
-	err := os.Remove(env)
+	err := os.Remove(conf.GetConfig().FheosDbPath)
 	if err != nil {
 		return err
 	}
-
-	return os.Setenv("FHEOS_DB_PATH", "")
+	return nil
 }
 
 func getenvInt(key string, defaultValue int) (int, error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,17 +68,21 @@ func initConfigs() (*fhedriver.Config, *conf.FheosConfig) {
 	return &configWd, &configFheos
 }
 
-func initKeys() (*precompiles.TxParams, error) {
+func initKeys() error {
 	securityZones, err := getenvInt("FHEOS_SECURITY_ZONES", 1)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	err = generateKeys(int32(securityZones))
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	tp := precompiles.TxParams{
+	return err
+}
+
+func mockTxParams() *precompiles.TxParams {
+	return &precompiles.TxParams{
 		false,
 		false,
 		true,
@@ -87,8 +91,6 @@ func initKeys() (*precompiles.TxParams, error) {
 		vm.GetHashFunc(nil),
 		nil,
 	}
-
-	return &tp, err
 }
 
 func getValue(a []byte) *big.Int {
@@ -141,11 +143,12 @@ func setupOperationCommand(use, short string, op operationFunc) *cobra.Command {
 			}
 			defer removeDb()
 
-			txParams, err := initKeys()
+			err = initKeys()
 			if err != nil {
 				return err
 			}
 
+			txParams := mockTxParams()
 			elhs, err := encrypt(lhs, t, securityZone, txParams)
 			if err != nil {
 				return err

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,7 @@ func initConfigs() (*fhedriver.Config, *conf.FheosConfig, error) {
 }
 
 func initKeys() error {
-	err = generateKeys(int32(securityZones))
+	err := generateKeys(conf.GetConfig().SecurityZones)
 	if err != nil {
 		return err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,7 +211,7 @@ func main() {
 		Use:   "init-state",
 		Short: "Initialize fheos state",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := initKeys()
+			err := initKeys()
 			return err
 		},
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -211,7 +211,16 @@ func main() {
 		Use:   "init-state",
 		Short: "Initialize fheos state",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := initKeys()
+			confWd, confFheos, err := initConfigs()
+			if err != nil {
+				return err
+			}
+			err = precompiles.InitFheos(confWd, confFheos)
+			if err != nil {
+				return err
+			}
+
+			err = initKeys()
 			return err
 		},
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,0 +1,1 @@
+package conf

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,1 +1,17 @@
 package conf
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+func FheosConfigAddOptions(prefix string, f *flag.FlagSet) {
+	f.String(prefix+".fheos-db-path", ConfigDefault.FheosDbPath, "Path for FheOs database")
+}
+
+type FheosConfig struct {
+	FheosDbPath string `koanf:"fheos-db-path"`
+}
+
+var ConfigDefault = FheosConfig{
+	FheosDbPath: "/tmp/fheos",
+}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,6 +1,8 @@
 package conf
 
 import (
+	"fmt"
+	"github.com/ethereum/go-ethereum/log"
 	flag "github.com/spf13/pflag"
 )
 
@@ -14,4 +16,15 @@ type FheosConfig struct {
 
 var ConfigDefault = FheosConfig{
 	FheosDbPath: "/tmp/fheos",
+}
+
+var loadedConfig FheosConfig
+
+func GetConfig() *FheosConfig {
+	return &loadedConfig
+}
+
+func SetConfig(config FheosConfig) {
+	log.Info(fmt.Sprintf("Setting Fheos config: %+v", config))
+	loadedConfig = config
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -8,14 +8,17 @@ import (
 
 func FheosConfigAddOptions(prefix string, f *flag.FlagSet) {
 	f.String(prefix+".fheos-db-path", ConfigDefault.FheosDbPath, "Path for FheOs database")
+	f.Int32(prefix+".security-zones", ConfigDefault.SecurityZones, "Amount of security Zones to load")
 }
 
 type FheosConfig struct {
-	FheosDbPath string `koanf:"fheos-db-path"`
+	FheosDbPath   string `koanf:"fheos-db-path"`
+	SecurityZones int32  `koanf:"security-zones"`
 }
 
 var ConfigDefault = FheosConfig{
-	FheosDbPath: "/tmp/fheos",
+	FheosDbPath:   "/tmp/fheos",
+	SecurityZones: 1,
 }
 
 var loadedConfig FheosConfig

--- a/deployment/run.sh
+++ b/deployment/run.sh
@@ -40,11 +40,11 @@ KEYS_PATH="/home/fhenix/keys/0/tfhe/sks"
 
 # Check if keys exist in the KEYS_PATH
 if [ "$(ls -A $KEYS_PATH 2>/dev/null)" ]; then
-    echo "Keys already exist in $KEYS_PATH, no need to initialize state."
+    echo "Keys already exist in $KEYS_PATH, no need to initialize keys."
 else
-    echo "No keys found in $KEYS_PATH. Initializing state..."
+    echo "No keys found in $KEYS_PATH. Initializing keys..."
     # Initialize the FHE state
-    FHEOS_SECURITY_ZONES=2 fheos init-state
+    FHEOS_SECURITY_ZONES=2 fheos init-keys
 
     # Wait for the keys to be loaded
     sleep 3

--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -3,6 +3,7 @@ package precompiles
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/fhenixprotocol/fheos/conf"
 	"math/big"
 	"os"
 	"strings"
@@ -49,11 +50,13 @@ func InitFheConfig(fheConfig *fhe.Config) error {
 	return nil
 }
 
-func InitFheos(tfheConfig *fhe.Config) error {
+func InitFheos(tfheConfig *fhe.Config, fheosConfig *conf.FheosConfig) error {
 	err := InitFheConfig(tfheConfig)
 	if err != nil {
 		return err
 	}
+
+	conf.SetConfig(*fheosConfig)
 
 	err = InitializeFheosState()
 	if err != nil {

--- a/precompiles/state.go
+++ b/precompiles/state.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fhenixprotocol/fheos/precompiles/types"
 	storage2 "github.com/fhenixprotocol/fheos/storage"
 	"github.com/fhenixprotocol/warp-drive/fhe-driver"
-	"os"
+	"github.com/fhenixprotocol/warp-drive/fhe-driver/internal/api"
 	"time"
 )
 
@@ -30,15 +30,6 @@ func (fs *FheosState) GetRandomForGasEstimation() []byte {
 }
 
 const FheosVersion = uint64(1001)
-
-func getDbPath() string {
-	dbPath := os.Getenv("FHEOS_DB_PATH")
-	if dbPath == "" {
-		return os.TempDir() + "/fheos"
-	}
-
-	return dbPath
-}
 
 var State *FheosState = nil
 
@@ -108,7 +99,8 @@ func createFheosState(storage storage2.FheosStorage, version uint64) {
 }
 
 func InitializeFheosState() error {
-	store, err := storage2.InitStorage(getDbPath())
+	config := api.GetConfig()
+	store, err := storage2.InitStorage(config.FheosDbPath)
 
 	if err != nil {
 		logger.Error("failed to open storage for fheos State")

--- a/precompiles/state.go
+++ b/precompiles/state.go
@@ -3,14 +3,15 @@ package precompiles
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/fhenixprotocol/fheos/conf"
 	"github.com/fhenixprotocol/fheos/precompiles/types"
 	storage2 "github.com/fhenixprotocol/fheos/storage"
 	"github.com/fhenixprotocol/warp-drive/fhe-driver"
-	"github.com/fhenixprotocol/warp-drive/fhe-driver/internal/api"
-	"time"
 )
 
 type FheosState struct {
@@ -99,8 +100,7 @@ func createFheosState(storage storage2.FheosStorage, version uint64) {
 }
 
 func InitializeFheosState() error {
-	config := api.GetConfig()
-	store, err := storage2.InitStorage(config.FheosDbPath)
+	store, err := storage2.InitStorage(conf.GetConfig().FheosDbPath)
 
 	if err != nil {
 		logger.Error("failed to open storage for fheos State")


### PR DESCRIPTION
Adding the option to configure fheos' db path via the file or the command-line options (note that fheo's main command still does not parse cmd args or config files, therefore a default configuration is initialized and environment variables are the still only methods to change behaviour).
* The new config field is `fheos` category under `conf` (not inside `fhenix` since that is the config that is going to the warp-drive which does not need to be aware of such things).
* The new inner fields are `fheos-db-path` and also included `fheos-security-zones` for the future to make it possible to configure the amount of security zones that are initialized. (This latter, however, can't be used directly right now, since it's accessible from nitro, but nitro does not use it at any point, it is used only via fheo's command line, which does not parse any config but instead only has a default value which can be overriden by the environment varialbe FHEOS_SECURITY_ZONES).

Side effects:
* using [this](https://github.com/FhenixProtocol/nitro/pull/181) quickfix which I bumped into to build nitro correctly
* the old config file can be used, as the new fields are optional.
* I changed the fheos command to use a new subcommand, `init-keys` instead of `init-state` because the latter was creating a db when it was unnecessary, since nitro created it again nevertheless. Now the `run.sh` uses `init-keys` instead, which is more pinpointed to do just that. Maybe we need to ping @davidecostantini that `run.sh` changed for later versions.

monday: 1638809482
nitro: https://github.com/FhenixProtocol/nitro/pull/182