### PR TITLE
Fix logging

### DIFF
--- a/precompiles/contracts.go
+++ b/precompiles/contracts.go
@@ -31,11 +31,14 @@ func InitLogger() {
 
 func InitFheConfig(fheConfig *fhe.Config) error {
 	// Itzik: I'm not sure if this is the right way to initialize the logger
+	fmt.Println("using legacy level", fheConfig.LogLevel)
+	fmt.Println("using slog level", log.FromLegacyLevel(fheConfig.LogLevel))
+
 	handler := log.NewTerminalHandlerWithLevel(os.Stderr, log.FromLegacyLevel(fheConfig.LogLevel), true)
 	glogger := log.NewGlogHandler(handler)
 
-	logger = log.NewLogger(glogger)
-	fhe.SetLogger(log.NewLogger(glogger))
+	logger = log.NewLogger(glogger).New("module", "fheos")
+	fhe.SetLogger(log.NewLogger(glogger).New("module", "warp-drive"))
 
 	err := fhe.Init(fheConfig)
 
@@ -93,6 +96,8 @@ func UtypeToString(utype byte) string {
 // ============================================================
 
 func Log(s string, tp *TxParams) (uint64, error) {
+	logger.Debug(fmt.Sprintf("Debug: Contract Log: %s", s))
+	logger.Info(fmt.Sprintf("Info: Contract Log: %s", s))
 	if tp.GasEstimation {
 		return 1, nil
 	}


### PR DESCRIPTION
fixed fheos logging. (which included contract logs but not only, it included all debugs!)
The problem was that when wrapping the handler with NewGlogHandler (are we using glog's functionality even?), there was a reset of the loglevel, for some reason, so I had to set it again with Verbosity.

Notes: there is also an `function init()` in fheos which initialized a logger which is not really used I believe, because later we do initFheos and we override this logger. Maybe we can remove the init function. 