### PR TITLE
Remove nil values fhesol

### DIFF
--- a/solgen/templates/library.ts
+++ b/solgen/templates/library.ts
@@ -142,10 +142,6 @@ library Impl {
 }
 
 library FHE {
-    euint8 public constant NIL8 = euint8.wrap(0);
-    euint16 public constant NIL16 = euint16.wrap(0);
-    euint32 public constant NIL32 = euint32.wrap(0);
-
     // Return true if the encrypted integer is initialized and false otherwise.
     function isInitialized(ebool v) internal pure returns (bool) {
         return ebool.unwrap(v) != 0;

--- a/solidity/FHE.sol
+++ b/solidity/FHE.sol
@@ -153,10 +153,6 @@ library Impl {
 }
 
 library FHE {
-    euint8 public constant NIL8 = euint8.wrap(0);
-    euint16 public constant NIL16 = euint16.wrap(0);
-    euint32 public constant NIL32 = euint32.wrap(0);
-
     // Return true if the encrypted integer is initialized and false otherwise.
     function isInitialized(ebool v) internal pure returns (bool) {
         return ebool.unwrap(v) != 0;


### PR DESCRIPTION
these values are unused, and caused warnings on compilation of contracts that use FHE.sol
![image](https://github.com/user-attachments/assets/1188fc8c-7f26-4c59-b40f-71e49d361b95)
