### PR TITLE
removing log.Crit()

### DIFF
--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -80,7 +80,7 @@ func (h FheOSHooksImpl) StoreCiphertextHook(contract common.Address, loc [32]byt
 	if wasDereferenced {
 		err = storage.MarkForPersistence(contract, types.Hash(commited))
 		if err != nil {
-			log.Crit("Error marking dereferenced ciphertext as LTS", "err", err)
+			log.Error("Error marking dereferenced ciphertext as LTS", "err", err)
 			return err
 		}
 	}
@@ -96,7 +96,7 @@ func (h FheOSHooksImpl) StoreCiphertextHook(contract common.Address, loc [32]byt
 
 	err = storage.MarkForPersistence(contract, val)
 	if err != nil {
-		log.Crit("Error marking ciphertext as LTS", "err", err)
+		log.Error("Error marking ciphertext as LTS", "err", err)
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (h FheOSHooksImpl) EvmCallEnd(evmSuccess bool) {
 			}
 			err = fheos.State.SetCiphertext(cipherText)
 			if err != nil {
-				log.Crit("Error storing ciphertext in LTS - state corruption detected", "err", err)
+				log.Error("Error storing ciphertext in LTS - state corruption detected", "err", err)
 			}
 		}
 


### PR DESCRIPTION
removing fheos Crit logs, which crash the node unnecessarily
there are still many such logs in go-ethereum, but I don't think we wanna change those