### PR TITLE
runCopro.sh with fhenix as DA

### DIFF
--- a/http/runCopro.sh
+++ b/http/runCopro.sh
@@ -5,7 +5,7 @@ AggregatorDir="$(pwd)/copro-aggregator"
 TaskManagerDir="$(pwd)/copro-task-manager-hardhat"
 CtRegistryDir="$(pwd)/ct-registry"
 FheosDir="$(pwd)/nitro/fheos/"
-FheosImage="ghcr.io/fhenixprotocol/localfhenix:v0.2.4"
+FheosImage="ghcr.io/fhenixprotocol/nitro/localfhenix:v0.3.2-alpha.17"
 FheosServerImage="fheosserver"
 
 BuildParam=$1

--- a/http/runCopro.sh
+++ b/http/runCopro.sh
@@ -33,7 +33,7 @@ if [ ! -d "$FheosDir" ]; then
   missing_dirs+=("Fheos Directory: $FheosDir")
 fi
 
-if [ ! -d "$FheosDir" ]; then
+if [ ! -d "$CtRegistryDir" ]; then
   missing_dirs+=("Ct Registry Directory: $CtRegistryDir")
 fi
 


### PR DESCRIPTION
runcopro now deploys a second fhenix chain to act as the DA, and deploys the ct-registry contract to that chain