### PR TITLE
Update ct hex

### DIFF
--- a/http/main.go
+++ b/http/main.go
@@ -685,7 +685,7 @@ func createNetworkPublicKeyResponse(PublicKey []byte) ([]byte, error) {
 }
 
 func hasHexPrefix(str string) bool {
-	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
+	return len(str) >= 2 && strings.HasPrefix(strings.ToLower(str), '0x')
 }
 
 func hexOnly(value string) string {

--- a/http/main.go
+++ b/http/main.go
@@ -685,7 +685,7 @@ func createNetworkPublicKeyResponse(PublicKey []byte) ([]byte, error) {
 }
 
 func hasHexPrefix(str string) bool {
-	return len(str) >= 2 && strings.HasPrefix(strings.ToLower(str), '0x')
+	return len(str) >= 2 && strings.HasPrefix(strings.ToLower(str), "0x")
 }
 
 func hexOnly(value string) string {

--- a/http/main.go
+++ b/http/main.go
@@ -684,6 +684,17 @@ func createNetworkPublicKeyResponse(PublicKey []byte) ([]byte, error) {
 	return responseData, nil
 }
 
+func has0xPrefix(str string) bool {
+	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
+}
+
+func hexOnly(value string) string {
+	if has0xPrefix(value) {
+		return value[2:]
+	}
+	return value
+}
+
 func UpdateCTHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Printf("Got a verify request from %s\n", r.RemoteAddr)
 	body, err := ioutil.ReadAll(r.Body)
@@ -699,7 +710,7 @@ func UpdateCTHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// fmt.Printf("Verify Request Value: %s\n", req.Value)
-	value, err := hex.DecodeString(req.Value)
+	value, err := hex.DecodeString(hexOnly(req.Value))
 	if err != nil {
 		e := fmt.Sprintf("Invalid Value: %s %+v", req.Value, err)
 		fmt.Println(e)

--- a/http/main.go
+++ b/http/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"fmt"
 	"io/ioutil"
 	"log"

--- a/http/main.go
+++ b/http/main.go
@@ -689,7 +689,7 @@ func has0xPrefix(str string) bool {
 }
 
 func hexOnly(value string) string {
-	if has0xPrefix(value) {
+	if hasHexPrefix(value) {
 		return value[2:]
 	}
 	return value

--- a/http/main.go
+++ b/http/main.go
@@ -204,7 +204,7 @@ type GenericHashRequest struct {
 }
 
 func convertInput(input CiphertextKeyAux) (*fhedriver.CiphertextKey, error) {
-	decoded, err := hex.DecodeString(input.Hash[2:])
+	decoded, err := hex.DecodeString(hexOnly(input.Hash[2:]))
 	if err != nil {
 		e := fmt.Sprintf("Invalid input hex string at position %s %+v", input.Hash, err)
 		return nil, fmt.Errorf(e)
@@ -499,7 +499,7 @@ func SealOutputHandler(w http.ResponseWriter, r *http.Request) {
 		Callback:    handleSealOutputResult,
 	}
 
-	pkey, err := hex.DecodeString(req.PKey)
+	pkey, err := hex.DecodeString(hexOnly(req.PKey))
 	if err != nil {
 		e := fmt.Sprintf("Invalid pkey: %s %+v", req.PKey, err)
 		fmt.Println(e)
@@ -567,7 +567,7 @@ func TrivialEncryptHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Convert the value strings to byte arrays
 	hexStr := fmt.Sprintf("%064x", req.Value)
-	value, err := hex.DecodeString(hexStr)
+	value, err := hex.DecodeString(hexOnly(hexStr))
 	if err != nil {
 		e := fmt.Sprintf("Invalid value: %s %+v", req.Value, err)
 		fmt.Println(e)

--- a/http/main.go
+++ b/http/main.go
@@ -684,7 +684,7 @@ func createNetworkPublicKeyResponse(PublicKey []byte) ([]byte, error) {
 	return responseData, nil
 }
 
-func has0xPrefix(str string) bool {
+func hasHexPrefix(str string) bool {
 	return len(str) >= 2 && str[0] == '0' && (str[1] == 'x' || str[1] == 'X')
 }
 


### PR DESCRIPTION
Whenever calling to hex.DecodeString ensure the syntax is without the `0x`

[cofhe.txt](https://github.com/user-attachments/files/18321518/cofhe.txt)

![image](https://github.com/user-attachments/assets/8ef723f1-2ae5-4e82-ba68-fdabbb4dae11)