### PR TITLE
Mock decrypt seal

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -31,10 +31,6 @@ jobs:
         with:
           file: Dockerfile
           context: .
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y netcat
       - name: Start Engine
         run: |
           make start-engine

--- a/http/main.go
+++ b/http/main.go
@@ -914,10 +914,10 @@ func main() {
 		http.HandleFunc(handler.Name, handler.Handler)
 	}
 
-	//http.HandleFunc("/Decrypt", DecryptHandler)
-	//http.HandleFunc("/SealOutput", SealOutputHandler)
-	http.HandleFunc("/Decrypt", DecryptHandlerMock)
-	http.HandleFunc("/SealOutput", SealOutputHandlerMock)
+	http.HandleFunc("/Decrypt", DecryptHandler)
+	http.HandleFunc("/SealOutput", SealOutputHandler)
+	http.HandleFunc("/QueryDecrypt", DecryptHandlerMock)
+	http.HandleFunc("/QuerySealOutput", SealOutputHandlerMock)
 	http.HandleFunc("/UpdateCT", UpdateCTHandler)
 	http.HandleFunc("/TrivialEncrypt", TrivialEncryptHandler)
 	http.HandleFunc("/Cast", CastHandler)

--- a/http/main.go
+++ b/http/main.go
@@ -916,8 +916,8 @@ func main() {
 
 	//http.HandleFunc("/Decrypt", DecryptHandler)
 	//http.HandleFunc("/SealOutput", SealOutputHandler)
-	http.HandleFunc("/decrypt", DecryptHandlerMock)
-	http.HandleFunc("/sealoutput", SealOutputHandlerMock)
+	http.HandleFunc("/Decrypt", DecryptHandlerMock)
+	http.HandleFunc("/SealOutput", SealOutputHandlerMock)
 	http.HandleFunc("/UpdateCT", UpdateCTHandler)
 	http.HandleFunc("/TrivialEncrypt", TrivialEncryptHandler)
 	http.HandleFunc("/Cast", CastHandler)

--- a/http/main.go
+++ b/http/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"strings"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -13,6 +12,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -37,6 +37,17 @@ type SealOutputRequest struct {
 	Key          fhedriver.CiphertextKey `json:"key"`
 	PKey         string                  `json:"pkey"`
 	RequesterUrl string                  `json:"requesterUrl"`
+}
+
+type MockDecryptRequest struct {
+	CtHash string `json:"ctHash"`
+	Permit string `json:"permit"`
+}
+
+type MockSealOutputRequest struct {
+	CtHash    string `json:"ctHash"`
+	Permit    string `json:"permit"`
+	PublicKey string `json:"publicKey"`
 }
 
 type VerifyRequest struct {


### PR DESCRIPTION
task:
two new apis:
decrypt - receives cthash and permit - returns plaintext value synchronically, ignores permit
sealoutput - receives cthash and publickey, permit- returns empty string

In practice, there were already these apis, in the form of `/Decrypt`, `/SealOutput`, for which I changed handlers to mocked ones.

monday: 1785484189